### PR TITLE
FEAT: Add downloadFile() method

### DIFF
--- a/Sources/EZNetworking/Other/URLSessionTaskProtocol.swift
+++ b/Sources/EZNetworking/Other/URLSessionTaskProtocol.swift
@@ -4,7 +4,6 @@ public protocol URLSessionTaskProtocol {
     func data(for request: URLRequest, delegate: (URLSessionTaskDelegate)?) async throws -> (Data, URLResponse)
     func dataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
 
-    func downloadTask(with request: URLRequest, completionHandler: @escaping @Sendable (URL?, URLResponse?, Error?) -> Void) -> URLSessionDownloadTask
-}
+    func downloadTask(with url: URL, completionHandler: @escaping @Sendable (URL?, URLResponse?, Error?) -> Void) -> URLSessionDownloadTask}
 
 extension URLSession: URLSessionTaskProtocol {}

--- a/Sources/EZNetworking/Other/URLSessionTaskProtocol.swift
+++ b/Sources/EZNetworking/Other/URLSessionTaskProtocol.swift
@@ -3,7 +3,9 @@ import Foundation
 public protocol URLSessionTaskProtocol {
     func data(for request: URLRequest, delegate: (URLSessionTaskDelegate)?) async throws -> (Data, URLResponse)
     func dataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
-
-    func downloadTask(with url: URL, completionHandler: @escaping @Sendable (URL?, URLResponse?, Error?) -> Void) -> URLSessionDownloadTask}
+    
+    func downloadTask(with url: URL, completionHandler: @escaping @Sendable (URL?, URLResponse?, Error?) -> Void) -> URLSessionDownloadTask
+    func download(from url: URL, delegate: (URLSessionTaskDelegate)?) async throws -> (URL, URLResponse)
+}
 
 extension URLSession: URLSessionTaskProtocol {}

--- a/Sources/EZNetworking/Other/URLSessionTaskProtocol.swift
+++ b/Sources/EZNetworking/Other/URLSessionTaskProtocol.swift
@@ -3,6 +3,8 @@ import Foundation
 public protocol URLSessionTaskProtocol {
     func data(for request: URLRequest, delegate: (URLSessionTaskDelegate)?) async throws -> (Data, URLResponse)
     func dataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
+
+    func downloadTask(with request: URLRequest, completionHandler: @escaping @Sendable (URL?, URLResponse?, Error?) -> Void) -> URLSessionDownloadTask
 }
 
 extension URLSession: URLSessionTaskProtocol {}

--- a/Sources/EZNetworking/Util/Performers/AsyncRequestPerformable.swift
+++ b/Sources/EZNetworking/Util/Performers/AsyncRequestPerformable.swift
@@ -44,4 +44,16 @@ public struct AsyncRequestPerformer: AsyncRequestPerformable {
             throw NetworkingError.unknown
         }
     }
+    
+    public func downloadFile(with url: URL) async throws -> URL {
+        do {
+            let (url, urlResponse) = try await urlSession.download(from: url, delegate: nil)
+            let localURL = try urlResponseValidator.validateDownloadTask(url: url, urlResponse: urlResponse, error: nil)
+            return localURL
+        } catch let error as NetworkingError {
+            throw error
+        } catch {
+            throw NetworkingError.unknown
+        }
+    }
 }

--- a/Sources/EZNetworking/Util/Performers/RequestPerformer.swift
+++ b/Sources/EZNetworking/Util/Performers/RequestPerformer.swift
@@ -3,6 +3,7 @@ import Foundation
 public protocol RequestPerformable {
     func perform<T: Decodable>(request: URLRequest, decodeTo decodableObject: T.Type, completion: @escaping((Result<T, NetworkingError>)) -> Void)
     func perform(request: URLRequest, completion: @escaping((VoidResult<NetworkingError>) -> Void))
+    func downloadFile(url: URL, completion: @escaping((Result<URL, NetworkingError>) -> Void))
 }
 
 public struct RequestPerformer: RequestPerformable {
@@ -49,6 +50,20 @@ public struct RequestPerformer: RequestPerformable {
             } catch {
                 completion(.failure(NetworkingError.unknown))
                 return
+            }
+        }
+        dataTask.resume()
+    }
+    
+    public func downloadFile(url: URL, completion: @escaping((Result<URL, NetworkingError>) -> Void)) {
+        let dataTask = urlSession.downloadTask(with: url) { localURL, response, error in
+            do {
+                let localURL = try urlResponseValidator.validateDownloadTask(url: localURL, urlResponse: response, error: error)
+                completion(.success(localURL))
+            } catch let networkError as NetworkingError {
+                completion(.failure(networkError))
+            } catch {
+                completion(.failure(.unknown))
             }
         }
         dataTask.resume()

--- a/Sources/EZNetworking/Validator/URLResponseValidator.swift
+++ b/Sources/EZNetworking/Validator/URLResponseValidator.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public protocol URLResponseValidator {
     func validate(data: Data?, urlResponse: URLResponse?, error: Error?) throws -> Data
+    func validateDownloadTask(url: URL?, urlResponse: URLResponse?, error: Error?) throws -> URL
 }
 
 public struct URLResponseValidatorImpl: URLResponseValidator {
@@ -24,6 +25,28 @@ public struct URLResponseValidatorImpl: URLResponseValidator {
         let errorResponse = httpURLResponse.networkingError
         if case .ok = errorResponse {
             return data
+        } else {
+            throw errorResponse
+        }
+    }
+    
+    public func validateDownloadTask(url: URL?, urlResponse: URLResponse?, error: Error?) throws -> URL {
+        guard let url else {
+            throw NetworkingError.noURL
+        }
+        guard let urlResponse else {
+            throw NetworkingError.noResponse
+        }
+        if let error = error {
+            throw NetworkingError.requestFailed(error)
+        }
+        guard let httpURLResponse = urlResponse as? HTTPURLResponse else {
+            throw NetworkingError.noHTTPURLResponse
+        }
+        
+        let errorResponse = httpURLResponse.networkingError
+        if case .ok = errorResponse {
+            return url
         } else {
             throw errorResponse
         }

--- a/Tests/EZNetworkingTests/Mocks/MockURLResponseValidator.swift
+++ b/Tests/EZNetworkingTests/Mocks/MockURLResponseValidator.swift
@@ -12,4 +12,14 @@ struct MockURLResponseValidator: URLResponseValidator {
         }
         throw throwError
     }
+    
+    func validateDownloadTask(url: URL?, urlResponse: URLResponse?, error: Error?) throws -> URL {
+        guard let throwError else {
+            guard let url else {
+                throw NetworkingError.noURL
+            }
+            return url
+        }
+        throw throwError
+    }
 }

--- a/Tests/EZNetworkingTests/Mocks/MockURLSession.swift
+++ b/Tests/EZNetworkingTests/Mocks/MockURLSession.swift
@@ -2,6 +2,7 @@ import Foundation
 import EZNetworking
 
 class MockURLSession: URLSessionTaskProtocol {
+    var url: URL?
     var data: Data?
     var urlResponse: URLResponse?
     var error: Error?
@@ -11,6 +12,14 @@ class MockURLSession: URLSessionTaskProtocol {
         self.data = data
         self.urlResponse = urlResponse
         self.error = error
+        self.url = nil
+    }
+    
+    init(url: URL? = nil, urlResponse: URLResponse? = nil, error: Error? = nil) {
+        self.url = url
+        self.urlResponse = urlResponse
+        self.error = error
+        self.data = nil
     }
     
     func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
@@ -31,14 +40,12 @@ class MockURLSession: URLSessionTaskProtocol {
         return (data, urlResponse)
     }
     
-    func downloadTask(with request: URLRequest, completionHandler: @escaping @Sendable (URL?, URLResponse?, Error?) -> Void) -> URLSessionDownloadTask {
+    func downloadTask(with url: URL, completionHandler: @escaping @Sendable (URL?, URLResponse?, Error?) -> Void) -> URLSessionDownloadTask {
         
         return MockURLSessionDownloadTask {
-            completionHandler(nil, nil, nil) // TODO: update later
+            completionHandler(URL(fileURLWithPath: "/tmp/test.pdf"), self.urlResponse, self.error) // TODO: update later
         }
     }
-
-
 }
 
 class MockURLSessionDataTask: URLSessionDataTask {

--- a/Tests/EZNetworkingTests/Mocks/MockURLSession.swift
+++ b/Tests/EZNetworkingTests/Mocks/MockURLSession.swift
@@ -46,6 +46,16 @@ class MockURLSession: URLSessionTaskProtocol {
             completionHandler(URL(fileURLWithPath: "/tmp/test.pdf"), self.urlResponse, self.error) // TODO: update later
         }
     }
+    
+    func download(from url: URL, delegate: (URLSessionTaskDelegate)?) async throws -> (URL, URLResponse) {
+        if let error = error {
+            throw error
+        }
+        guard let urlResponse else {
+            throw NetworkingError.unknown
+        }
+        return (URL(fileURLWithPath: "/tmp/test.pdf"), urlResponse)
+    }
 }
 
 class MockURLSessionDataTask: URLSessionDataTask {

--- a/Tests/EZNetworkingTests/Mocks/MockURLSession.swift
+++ b/Tests/EZNetworkingTests/Mocks/MockURLSession.swift
@@ -30,10 +30,30 @@ class MockURLSession: URLSessionTaskProtocol {
         }
         return (data, urlResponse)
     }
+    
+    func downloadTask(with request: URLRequest, completionHandler: @escaping @Sendable (URL?, URLResponse?, Error?) -> Void) -> URLSessionDownloadTask {
+        
+        return MockURLSessionDownloadTask {
+            completionHandler(nil, nil, nil) // TODO: update later
+        }
+    }
+
 
 }
 
 class MockURLSessionDataTask: URLSessionDataTask {
+    private let closure: () -> Void
+    
+    init(closure: @escaping () -> Void) {
+        self.closure = closure
+    }
+    
+    override func resume() {
+        closure()
+    }
+}
+
+class MockURLSessionDownloadTask: URLSessionDownloadTask {
     private let closure: () -> Void
     
     init(closure: @escaping () -> Void) {

--- a/Tests/EZNetworkingTests/Mocks/MockURLSession.swift
+++ b/Tests/EZNetworkingTests/Mocks/MockURLSession.swift
@@ -43,7 +43,7 @@ class MockURLSession: URLSessionTaskProtocol {
     func downloadTask(with url: URL, completionHandler: @escaping @Sendable (URL?, URLResponse?, Error?) -> Void) -> URLSessionDownloadTask {
         
         return MockURLSessionDownloadTask {
-            completionHandler(URL(fileURLWithPath: "/tmp/test.pdf"), self.urlResponse, self.error) // TODO: update later
+            completionHandler(URL(fileURLWithPath: "/tmp/test.pdf"), self.urlResponse, self.error)
         }
     }
     

--- a/Tests/EZNetworkingTests/Util/Performers/AsyncRequestPerformableTests.swift
+++ b/Tests/EZNetworkingTests/Util/Performers/AsyncRequestPerformableTests.swift
@@ -162,7 +162,7 @@ final class AsyncRequestPerformableTests: XCTestCase {
         do {
             let localURL = try await sut.downloadFile(with: testURL)
             XCTAssertEqual(localURL.absoluteString, "file:///tmp/test.pdf")
-        } catch let error as NetworkingError{
+        } catch {
             XCTFail()
         }
     }
@@ -179,7 +179,7 @@ final class AsyncRequestPerformableTests: XCTestCase {
         let sut = AsyncRequestPerformer(urlSession: urlSession, urlResponseValidator: validator, requestDecoder: decoder)
         
         do {
-            let localURL = try await sut.downloadFile(with: testURL)
+            _ = try await sut.downloadFile(with: testURL)
             XCTFail("unexpected error")
         } catch let error as NetworkingError{
             XCTAssertEqual(error, NetworkingError.forbidden)
@@ -198,7 +198,7 @@ final class AsyncRequestPerformableTests: XCTestCase {
         let sut = AsyncRequestPerformer(urlSession: urlSession, urlResponseValidator: validator, requestDecoder: decoder)
         
         do {
-            let localURL = try await sut.downloadFile(with: testURL)
+            _ = try await sut.downloadFile(with: testURL)
             XCTFail("unexpected error")
         } catch let error as NetworkingError{
             XCTAssertEqual(error, NetworkingError.badRequest)
@@ -217,7 +217,7 @@ final class AsyncRequestPerformableTests: XCTestCase {
         let sut = AsyncRequestPerformer(urlSession: urlSession, urlResponseValidator: validator, requestDecoder: decoder)
         
         do {
-            let localURL = try await sut.downloadFile(with: testURL)
+            _ = try await sut.downloadFile(with: testURL)
             XCTFail("unexpected error")
         } catch let error as NetworkingError{
             XCTAssertEqual(error, NetworkingError.unknown)

--- a/Tests/EZNetworkingTests/Validator/URLResponseValidatorTests.swift
+++ b/Tests/EZNetworkingTests/Validator/URLResponseValidatorTests.swift
@@ -83,10 +83,10 @@ final class URLResponseValidatorTests: XCTestCase {
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
         
         do {
-            try validator.validateDownloadTask(url: url, urlResponse: response, error: nil)
+            _ = try validator.validateDownloadTask(url: url, urlResponse: response, error: nil)
             XCTAssertTrue(true)
         } catch let error as NetworkingError {
-            XCTFail("Unexpected error")
+            XCTFail("Unexpected error: \(error)")
         }
     }
     
@@ -96,7 +96,7 @@ final class URLResponseValidatorTests: XCTestCase {
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
         
         do {
-            try validator.validateDownloadTask(url: nil, urlResponse: response, error: nil)
+            _ = try validator.validateDownloadTask(url: nil, urlResponse: response, error: nil)
             XCTFail("Unexpected error")
         } catch let error as NetworkingError {
             XCTAssertEqual(error, NetworkingError.noURL)
@@ -106,10 +106,9 @@ final class URLResponseValidatorTests: XCTestCase {
     func testValidateDownloadTaskFailsWhenUrlResponseIsNil() throws {
         let validator = URLResponseValidatorImpl()
         let url = URL(string: "https://example.com")!
-        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
         
         do {
-            try validator.validateDownloadTask(url: url, urlResponse: nil, error: nil)
+            _ = try validator.validateDownloadTask(url: url, urlResponse: nil, error: nil)
             XCTFail("Unexpected error")
         } catch let error as NetworkingError {
             XCTAssertEqual(error, NetworkingError.noResponse)
@@ -122,7 +121,7 @@ final class URLResponseValidatorTests: XCTestCase {
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
         
         do {
-            try validator.validateDownloadTask(url: url, urlResponse: response, error: NetworkingError.unknown)
+            _ = try validator.validateDownloadTask(url: url, urlResponse: response, error: NetworkingError.unknown)
             XCTFail("Unexpected error")
         } catch let error as NetworkingError {
             XCTAssertEqual(error, NetworkingError.requestFailed(NetworkingError.unknown))
@@ -135,7 +134,7 @@ final class URLResponseValidatorTests: XCTestCase {
         let response = URLResponse(url: url, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
 
         do {
-            try validator.validateDownloadTask(url: url, urlResponse: response, error: nil)
+            _ = try validator.validateDownloadTask(url: url, urlResponse: response, error: nil)
             XCTFail("Unexpected error")
         } catch let error as NetworkingError {
             XCTAssertEqual(error, NetworkingError.noHTTPURLResponse)
@@ -148,7 +147,7 @@ final class URLResponseValidatorTests: XCTestCase {
         let response = HTTPURLResponse(url: url, statusCode: 400, httpVersion: nil, headerFields: nil)!
         
         do {
-            try validator.validateDownloadTask(url: url, urlResponse: response, error: nil)
+            _ = try validator.validateDownloadTask(url: url, urlResponse: response, error: nil)
             XCTFail("Unexpected error")
         } catch let error as NetworkingError {
             XCTAssertEqual(error, NetworkingError.badRequest)

--- a/Tests/EZNetworkingTests/Validator/URLResponseValidatorTests.swift
+++ b/Tests/EZNetworkingTests/Validator/URLResponseValidatorTests.swift
@@ -3,6 +3,8 @@ import XCTest
 
 final class URLResponseValidatorTests: XCTestCase {
     
+    // MARK: - test validate()
+
     func testValidateOKResponse() throws {
         let validator = URLResponseValidatorImpl()
         let response = HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)!
@@ -72,5 +74,84 @@ final class URLResponseValidatorTests: XCTestCase {
             XCTAssertEqual(error, NetworkingError.requestFailed(NetworkingError.badGateway))
         }
     }
+
+    // MARK: - test validateDownloadTask()
+
+    func testValidateDownloadTaskOKResponse() throws {
+        let validator = URLResponseValidatorImpl()
+        let url = URL(string: "https://example.com")!
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        
+        do {
+            try validator.validateDownloadTask(url: url, urlResponse: response, error: nil)
+            XCTAssertTrue(true)
+        } catch let error as NetworkingError {
+            XCTFail("Unexpected error")
+        }
+    }
     
+    func testValidateDownloadTaskFailsWhenUrlIsNil() throws {
+        let validator = URLResponseValidatorImpl()
+        let url = URL(string: "https://example.com")!
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        
+        do {
+            try validator.validateDownloadTask(url: nil, urlResponse: response, error: nil)
+            XCTFail("Unexpected error")
+        } catch let error as NetworkingError {
+            XCTAssertEqual(error, NetworkingError.noURL)
+        }
+    }
+    
+    func testValidateDownloadTaskFailsWhenUrlResponseIsNil() throws {
+        let validator = URLResponseValidatorImpl()
+        let url = URL(string: "https://example.com")!
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        
+        do {
+            try validator.validateDownloadTask(url: url, urlResponse: nil, error: nil)
+            XCTFail("Unexpected error")
+        } catch let error as NetworkingError {
+            XCTAssertEqual(error, NetworkingError.noResponse)
+        }
+    }
+    
+    func testValidateDownloadTaskFailsWhenErrorIsNotNil() throws {
+        let validator = URLResponseValidatorImpl()
+        let url = URL(string: "https://example.com")!
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        
+        do {
+            try validator.validateDownloadTask(url: url, urlResponse: response, error: NetworkingError.unknown)
+            XCTFail("Unexpected error")
+        } catch let error as NetworkingError {
+            XCTAssertEqual(error, NetworkingError.requestFailed(NetworkingError.unknown))
+        }
+    }
+    
+    func testValidateDownloadTaskFailsWhenResposneIsNotHTTPURLResponse() throws {
+        let validator = URLResponseValidatorImpl()
+        let url = URL(string: "https://example.com")!
+        let response = URLResponse(url: url, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
+
+        do {
+            try validator.validateDownloadTask(url: url, urlResponse: response, error: nil)
+            XCTFail("Unexpected error")
+        } catch let error as NetworkingError {
+            XCTAssertEqual(error, NetworkingError.noHTTPURLResponse)
+        }
+    }
+    
+    func testValidateDownloadTaskFailsWhenResponseStatusCodeIsNot200() throws {
+        let validator = URLResponseValidatorImpl()
+        let url = URL(string: "https://example.com")!
+        let response = HTTPURLResponse(url: url, statusCode: 400, httpVersion: nil, headerFields: nil)!
+        
+        do {
+            try validator.validateDownloadTask(url: url, urlResponse: response, error: nil)
+            XCTFail("Unexpected error")
+        } catch let error as NetworkingError {
+            XCTAssertEqual(error, NetworkingError.badRequest)
+        }
+    }
 }


### PR DESCRIPTION
Add a new method called downlaodFile() to `RequestPerformable` and `AsyncRequestPerformable`. 
Also added unit tests.