### PR TITLE
Return url session data task

### DIFF
--- a/Sources/EZNetworking/Util/EZNetworkUtil.swift
+++ b/Sources/EZNetworking/Util/EZNetworkUtil.swift
@@ -50,7 +50,7 @@ class EZNetworkUtil {
             return
         }
         
-        performer.perform(request: request, decodeTo: type, completion: completion).resume()
+        performer.performTask(request: request, decodeTo: type, completion: completion).resume()
     }
     
     
@@ -59,6 +59,6 @@ class EZNetworkUtil {
             completion(.failure(NetworkingError.noRequest))
             return
         }
-        performer.perform(request: request, completion: completion).resume()
+        performer.performTask(request: request, completion: completion).resume()
     }
 }

--- a/Sources/EZNetworking/Util/EZNetworkUtil.swift
+++ b/Sources/EZNetworking/Util/EZNetworkUtil.swift
@@ -50,7 +50,7 @@ class EZNetworkUtil {
             return
         }
         
-        performer.perform(request: request, decodeTo: type, completion: completion)
+        performer.perform(request: request, decodeTo: type, completion: completion).resume()
     }
     
     
@@ -59,6 +59,6 @@ class EZNetworkUtil {
             completion(.failure(NetworkingError.noRequest))
             return
         }
-        performer.perform(request: request, completion: completion)
+        performer.perform(request: request, completion: completion).resume()
     }
 }

--- a/Sources/EZNetworking/Util/Performers/RequestPerformer.swift
+++ b/Sources/EZNetworking/Util/Performers/RequestPerformer.swift
@@ -4,7 +4,7 @@ import UIKit
 public protocol RequestPerformable {
     func perform<T: Decodable>(request: URLRequest, decodeTo decodableObject: T.Type, completion: @escaping((Result<T, NetworkingError>)) -> Void) -> URLSessionDataTask
     func perform(request: URLRequest, completion: @escaping((VoidResult<NetworkingError>) -> Void)) -> URLSessionDataTask
-    func downloadFile(url: URL, completion: @escaping((Result<URL, NetworkingError>) -> Void))
+    func downloadFile(url: URL, completion: @escaping((Result<URL, NetworkingError>) -> Void)) -> URLSessionDownloadTask
     func downloadImage(url: URL, completion: @escaping((Result<UIImage, NetworkingError>) -> Void))
 }
 
@@ -55,8 +55,8 @@ public struct RequestPerformer: RequestPerformable {
         }
     }
     
-    public func downloadFile(url: URL, completion: @escaping((Result<URL, NetworkingError>) -> Void)) {
-        let dataTask = urlSession.downloadTask(with: url) { localURL, response, error in
+    public func downloadFile(url: URL, completion: @escaping((Result<URL, NetworkingError>) -> Void)) -> URLSessionDownloadTask {
+        return urlSession.downloadTask(with: url) { localURL, response, error in
             do {
                 let localURL = try urlResponseValidator.validateDownloadTask(url: localURL, urlResponse: response, error: error)
                 completion(.success(localURL))
@@ -66,7 +66,6 @@ public struct RequestPerformer: RequestPerformable {
                 completion(.failure(.unknown))
             }
         }
-        dataTask.resume()
     }
     
     public func downloadImage(url: URL, completion: @escaping((Result<UIImage, NetworkingError>) -> Void)) {

--- a/Sources/EZNetworking/Util/Performers/RequestPerformer.swift
+++ b/Sources/EZNetworking/Util/Performers/RequestPerformer.swift
@@ -2,8 +2,8 @@ import Foundation
 import UIKit
 
 public protocol RequestPerformable {
-    func perform<T: Decodable>(request: URLRequest, decodeTo decodableObject: T.Type, completion: @escaping((Result<T, NetworkingError>)) -> Void)
-    func perform(request: URLRequest, completion: @escaping((VoidResult<NetworkingError>) -> Void))
+    func perform<T: Decodable>(request: URLRequest, decodeTo decodableObject: T.Type, completion: @escaping((Result<T, NetworkingError>)) -> Void) -> URLSessionDataTask
+    func perform(request: URLRequest, completion: @escaping((VoidResult<NetworkingError>) -> Void)) -> URLSessionDataTask
     func downloadFile(url: URL, completion: @escaping((Result<URL, NetworkingError>) -> Void))
     func downloadImage(url: URL, completion: @escaping((Result<UIImage, NetworkingError>) -> Void))
 }
@@ -23,8 +23,8 @@ public struct RequestPerformer: RequestPerformable {
     }
     
     // MARK: perform using Completion Handler
-    public func perform<T: Decodable>(request: URLRequest, decodeTo decodableObject: T.Type, completion: @escaping ((Result<T, NetworkingError>)) -> Void) {
-        let dataTask = urlSession.dataTask(with: request) { data, urlResponse, error in
+    public func perform<T: Decodable>(request: URLRequest, decodeTo decodableObject: T.Type, completion: @escaping ((Result<T, NetworkingError>)) -> Void) -> URLSessionDataTask {
+        return urlSession.dataTask(with: request) { data, urlResponse, error in
             do {
                 let validData = try urlResponseValidator.validate(data: data, urlResponse: urlResponse, error: error)
                 let decodedObject = try requestDecoder.decode(decodableObject.self, from: validData)
@@ -37,12 +37,11 @@ public struct RequestPerformer: RequestPerformable {
                 return
             }
         }
-        dataTask.resume()
     }
     
     // MARK: perform using Completion Handler without returning Decodable
-    public func perform(request: URLRequest, completion: @escaping ((VoidResult<NetworkingError>) -> Void)) {
-        let dataTask = urlSession.dataTask(with: request) { data, urlResponse, error in
+    public func perform(request: URLRequest, completion: @escaping ((VoidResult<NetworkingError>) -> Void)) -> URLSessionDataTask {
+        return urlSession.dataTask(with: request) { data, urlResponse, error in
             do {
                 _ = try urlResponseValidator.validate(data: data, urlResponse: urlResponse, error: error)
                 completion(.success)
@@ -54,7 +53,6 @@ public struct RequestPerformer: RequestPerformable {
                 return
             }
         }
-        dataTask.resume()
     }
     
     public func downloadFile(url: URL, completion: @escaping((Result<URL, NetworkingError>) -> Void)) {

--- a/Sources/EZNetworking/Util/Performers/RequestPerformer.swift
+++ b/Sources/EZNetworking/Util/Performers/RequestPerformer.swift
@@ -5,7 +5,7 @@ public protocol RequestPerformable {
     func perform<T: Decodable>(request: URLRequest, decodeTo decodableObject: T.Type, completion: @escaping((Result<T, NetworkingError>)) -> Void) -> URLSessionDataTask
     func perform(request: URLRequest, completion: @escaping((VoidResult<NetworkingError>) -> Void)) -> URLSessionDataTask
     func downloadFile(url: URL, completion: @escaping((Result<URL, NetworkingError>) -> Void)) -> URLSessionDownloadTask
-    func downloadImage(url: URL, completion: @escaping((Result<UIImage, NetworkingError>) -> Void))
+    func downloadImage(url: URL, completion: @escaping((Result<UIImage, NetworkingError>) -> Void)) -> URLSessionDataTask
 }
 
 public struct RequestPerformer: RequestPerformable {
@@ -68,8 +68,8 @@ public struct RequestPerformer: RequestPerformable {
         }
     }
     
-    public func downloadImage(url: URL, completion: @escaping((Result<UIImage, NetworkingError>) -> Void)) {
-        let dataTask = urlSession.dataTask(with: url) { data, response, error in
+    public func downloadImage(url: URL, completion: @escaping((Result<UIImage, NetworkingError>) -> Void)) -> URLSessionDataTask {
+        return urlSession.dataTask(with: url) { data, response, error in
             do {
                 let validData = try self.urlResponseValidator.validate(data: data, urlResponse: response, error: error)
                 guard let image = UIImage(data: validData) else {
@@ -82,6 +82,5 @@ public struct RequestPerformer: RequestPerformable {
                 completion(.failure(.unknown))
             }
         }
-        dataTask.resume()
     }
 }

--- a/Sources/EZNetworking/Util/Performers/RequestPerformer.swift
+++ b/Sources/EZNetworking/Util/Performers/RequestPerformer.swift
@@ -2,10 +2,10 @@ import Foundation
 import UIKit
 
 public protocol RequestPerformable {
-    func perform<T: Decodable>(request: URLRequest, decodeTo decodableObject: T.Type, completion: @escaping((Result<T, NetworkingError>)) -> Void) -> URLSessionDataTask
-    func perform(request: URLRequest, completion: @escaping((VoidResult<NetworkingError>) -> Void)) -> URLSessionDataTask
-    func downloadFile(url: URL, completion: @escaping((Result<URL, NetworkingError>) -> Void)) -> URLSessionDownloadTask
-    func downloadImage(url: URL, completion: @escaping((Result<UIImage, NetworkingError>) -> Void)) -> URLSessionDataTask
+    func performTask<T: Decodable>(request: URLRequest, decodeTo decodableObject: T.Type, completion: @escaping((Result<T, NetworkingError>)) -> Void) -> URLSessionDataTask
+    func performTask(request: URLRequest, completion: @escaping((VoidResult<NetworkingError>) -> Void)) -> URLSessionDataTask
+    func downloadFileTask(url: URL, completion: @escaping((Result<URL, NetworkingError>) -> Void)) -> URLSessionDownloadTask
+    func downloadImageTask(url: URL, completion: @escaping((Result<UIImage, NetworkingError>) -> Void)) -> URLSessionDataTask
 }
 
 public struct RequestPerformer: RequestPerformable {
@@ -23,7 +23,7 @@ public struct RequestPerformer: RequestPerformable {
     }
     
     // MARK: perform using Completion Handler
-    public func perform<T: Decodable>(request: URLRequest, decodeTo decodableObject: T.Type, completion: @escaping ((Result<T, NetworkingError>)) -> Void) -> URLSessionDataTask {
+    public func performTask<T: Decodable>(request: URLRequest, decodeTo decodableObject: T.Type, completion: @escaping ((Result<T, NetworkingError>)) -> Void) -> URLSessionDataTask {
         return urlSession.dataTask(with: request) { data, urlResponse, error in
             do {
                 let validData = try urlResponseValidator.validate(data: data, urlResponse: urlResponse, error: error)
@@ -40,7 +40,7 @@ public struct RequestPerformer: RequestPerformable {
     }
     
     // MARK: perform using Completion Handler without returning Decodable
-    public func perform(request: URLRequest, completion: @escaping ((VoidResult<NetworkingError>) -> Void)) -> URLSessionDataTask {
+    public func performTask(request: URLRequest, completion: @escaping ((VoidResult<NetworkingError>) -> Void)) -> URLSessionDataTask {
         return urlSession.dataTask(with: request) { data, urlResponse, error in
             do {
                 _ = try urlResponseValidator.validate(data: data, urlResponse: urlResponse, error: error)
@@ -55,7 +55,7 @@ public struct RequestPerformer: RequestPerformable {
         }
     }
     
-    public func downloadFile(url: URL, completion: @escaping((Result<URL, NetworkingError>) -> Void)) -> URLSessionDownloadTask {
+    public func downloadFileTask(url: URL, completion: @escaping((Result<URL, NetworkingError>) -> Void)) -> URLSessionDownloadTask {
         return urlSession.downloadTask(with: url) { localURL, response, error in
             do {
                 let localURL = try urlResponseValidator.validateDownloadTask(url: localURL, urlResponse: response, error: error)
@@ -68,7 +68,7 @@ public struct RequestPerformer: RequestPerformable {
         }
     }
     
-    public func downloadImage(url: URL, completion: @escaping((Result<UIImage, NetworkingError>) -> Void)) -> URLSessionDataTask {
+    public func downloadImageTask(url: URL, completion: @escaping((Result<UIImage, NetworkingError>) -> Void)) -> URLSessionDataTask {
         return urlSession.dataTask(with: url) { data, response, error in
             do {
                 let validData = try self.urlResponseValidator.validate(data: data, urlResponse: response, error: error)

--- a/Tests/EZNetworkingTests/Util/Performers/RequestPerformerTests.swift
+++ b/Tests/EZNetworkingTests/Util/Performers/RequestPerformerTests.swift
@@ -22,7 +22,7 @@ final class RequestPerformerTests: XCTestCase {
         }
         
         var didExecute = false
-        sut.perform(request: request, decodeTo: Person.self) { result in
+        sut.performTask(request: request, decodeTo: Person.self) { result in
             didExecute = true
             switch result {
             case .success(let person):
@@ -51,7 +51,7 @@ final class RequestPerformerTests: XCTestCase {
         }
         
         var didExecute = false
-        sut.perform(request: request, decodeTo: Person.self) { result in
+        sut.performTask(request: request, decodeTo: Person.self) { result in
             didExecute = true
             switch result {
             case .success:
@@ -79,7 +79,7 @@ final class RequestPerformerTests: XCTestCase {
         }
         
         var didExecute = false
-        sut.perform(request: request, decodeTo: Person.self) { result in
+        sut.performTask(request: request, decodeTo: Person.self) { result in
             didExecute = true
             switch result {
             case .success:
@@ -107,7 +107,7 @@ final class RequestPerformerTests: XCTestCase {
         }
         
         var didExecute = false
-        sut.perform(request: request, decodeTo: Person.self) { result in
+        sut.performTask(request: request, decodeTo: Person.self) { result in
             didExecute = true
             switch result {
             case .success:
@@ -135,7 +135,7 @@ final class RequestPerformerTests: XCTestCase {
         }
         
         var didExecute = false
-        sut.perform(request: request, decodeTo: Person.self) { result in
+        sut.performTask(request: request, decodeTo: Person.self) { result in
             didExecute = true
             switch result {
             case .success:
@@ -163,7 +163,7 @@ final class RequestPerformerTests: XCTestCase {
         }
         
         var didExecute = false
-        sut.perform(request: request, decodeTo: Person.self) { result in
+        sut.performTask(request: request, decodeTo: Person.self) { result in
             didExecute = true
             switch result {
             case .success:
@@ -193,7 +193,7 @@ final class RequestPerformerTests: XCTestCase {
         }
         
         var didExecute = false
-        sut.perform(request: request) { result in
+        sut.performTask(request: request) { result in
             didExecute = true
             switch result {
             case .success:
@@ -221,7 +221,7 @@ final class RequestPerformerTests: XCTestCase {
         }
         
         var didExecute = false
-        sut.perform(request: request) { result in
+        sut.performTask(request: request) { result in
             didExecute = true
             switch result {
             case .success:
@@ -249,7 +249,7 @@ final class RequestPerformerTests: XCTestCase {
         }
         
         var didExecute = false
-        sut.perform(request: request) { result in
+        sut.performTask(request: request) { result in
             didExecute = true
             switch result {
             case .success:
@@ -277,7 +277,7 @@ final class RequestPerformerTests: XCTestCase {
         }
         
         var didExecute = false
-        sut.perform(request: request) { result in
+        sut.performTask(request: request) { result in
             didExecute = true
             switch result {
             case .success:
@@ -305,7 +305,7 @@ final class RequestPerformerTests: XCTestCase {
         }
         
         var didExecute = false
-        sut.perform(request: request) { result in
+        sut.performTask(request: request) { result in
             didExecute = true
             switch result {
             case .success:
@@ -329,7 +329,7 @@ final class RequestPerformerTests: XCTestCase {
                                    requestDecoder: RequestDecoder())
         
         var didExecute = false
-        sut.downloadFile(url: testURL) { result in
+        sut.downloadFileTask(url: testURL) { result in
             didExecute = true
             switch result {
             case .success(let localURL):
@@ -352,7 +352,7 @@ final class RequestPerformerTests: XCTestCase {
                                    requestDecoder: RequestDecoder())
         
         var didExecute = false
-        sut.downloadFile(url: testURL) { result in
+        sut.downloadFileTask(url: testURL) { result in
             didExecute = true
             switch result {
             case .success:
@@ -375,7 +375,7 @@ final class RequestPerformerTests: XCTestCase {
         let sut = RequestPerformer(urlSession: urlSession, urlResponseValidator: validator)
         
         var didExecute = false
-        sut.downloadImage(url: testURL) { result in
+        sut.downloadImageTask(url: testURL) { result in
             didExecute = true
             switch result {
             case .success:
@@ -402,7 +402,7 @@ final class RequestPerformerTests: XCTestCase {
                                    requestDecoder: RequestDecoder())
         
         var didExecute = false
-        sut.downloadImage(url: testURL) { result in
+        sut.downloadImageTask(url: testURL) { result in
             didExecute = true
             switch result {
             case .success:

--- a/Tests/EZNetworkingTests/Util/Performers/RequestPerformerTests.swift
+++ b/Tests/EZNetworkingTests/Util/Performers/RequestPerformerTests.swift
@@ -21,7 +21,9 @@ final class RequestPerformerTests: XCTestCase {
             return
         }
         
+        var didExecute = false
         sut.perform(request: request, decodeTo: Person.self) { result in
+            didExecute = true
             switch result {
             case .success(let person):
                 XCTAssertEqual(person.name, "John")
@@ -29,7 +31,8 @@ final class RequestPerformerTests: XCTestCase {
             case .failure:
                 XCTFail()
             }
-        }
+        }.resume()
+        XCTAssertTrue(didExecute)
     }
     
     func testPerformWithCompletionHandlerWithErrorFails() {
@@ -47,14 +50,17 @@ final class RequestPerformerTests: XCTestCase {
             return
         }
         
+        var didExecute = false
         sut.perform(request: request, decodeTo: Person.self) { result in
+            didExecute = true
             switch result {
             case .success:
                 XCTFail()
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.forbidden)
             }
-        }
+        }.resume()
+        XCTAssertTrue(didExecute)
     }
     
     func testPerformWithCompletionHandlerWithBadStatusCodeFails() {
@@ -72,14 +78,17 @@ final class RequestPerformerTests: XCTestCase {
             return
         }
         
+        var didExecute = false
         sut.perform(request: request, decodeTo: Person.self) { result in
+            didExecute = true
             switch result {
             case .success:
                 XCTFail()
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.badRequest)
             }
-        }
+        }.resume()
+        XCTAssertTrue(didExecute)
     }
     
     func testPerformWithCompletionHandlerWithInvalidData() {
@@ -97,14 +106,17 @@ final class RequestPerformerTests: XCTestCase {
             return
         }
         
+        var didExecute = false
         sut.perform(request: request, decodeTo: Person.self) { result in
+            didExecute = true
             switch result {
             case .success:
                 XCTFail()
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.couldNotParse)
             }
-        }
+        }.resume()
+        XCTAssertTrue(didExecute)
     }
     
     func testPerformWithCompletionHandlerWithNilData() {
@@ -122,14 +134,17 @@ final class RequestPerformerTests: XCTestCase {
             return
         }
         
+        var didExecute = false
         sut.perform(request: request, decodeTo: Person.self) { result in
+            didExecute = true
             switch result {
             case .success:
                 XCTFail()
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.noData)
             }
-        }
+        }.resume()
+        XCTAssertTrue(didExecute)
     }
     
     func testPerformWithCompletionHandlerWithNilResponse() {
@@ -147,14 +162,17 @@ final class RequestPerformerTests: XCTestCase {
             return
         }
         
+        var didExecute = false
         sut.perform(request: request, decodeTo: Person.self) { result in
+            didExecute = true
             switch result {
             case .success:
                 XCTFail()
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.couldNotParse)
             }
-        }
+        }.resume()
+        XCTAssertTrue(didExecute)
     }
     
     // MARK: Unit tests for perform using Completion Handler without Decodable response
@@ -174,14 +192,17 @@ final class RequestPerformerTests: XCTestCase {
             return
         }
         
+        var didExecute = false
         sut.perform(request: request) { result in
+            didExecute = true
             switch result {
             case .success:
                 XCTAssertTrue(true)
             case .failure:
                 XCTFail()
             }
-        }
+        }.resume()
+        XCTAssertTrue(didExecute)
     }
     
     func testPerformWithCompletionHandlerWithoutDecodableWithErrorFails() {
@@ -199,14 +220,17 @@ final class RequestPerformerTests: XCTestCase {
             return
         }
         
+        var didExecute = false
         sut.perform(request: request) { result in
+            didExecute = true
             switch result {
             case .success:
                 XCTFail()
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.forbidden)
             }
-        }
+        }.resume()
+        XCTAssertTrue(didExecute)
     }
     
     func testPerformWithCompletionHandlerWithoutDecodableWithBadStatusCodeFails() {
@@ -224,14 +248,17 @@ final class RequestPerformerTests: XCTestCase {
             return
         }
         
+        var didExecute = false
         sut.perform(request: request) { result in
+            didExecute = true
             switch result {
             case .success:
                 XCTFail()
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.badRequest)
             }
-        }
+        }.resume()
+        XCTAssertTrue(didExecute)
     }
     
     func testPerformWithCompletionHandlerWithoutDecodableWithNilData() {
@@ -249,14 +276,17 @@ final class RequestPerformerTests: XCTestCase {
             return
         }
         
+        var didExecute = false
         sut.perform(request: request) { result in
+            didExecute = true
             switch result {
             case .success:
                 XCTFail()
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.noData)
             }
-        }
+        }.resume()
+        XCTAssertTrue(didExecute)
     }
     
     func testPerformWithCompletionHandlerWithoutDecodableWithNilResponse() {
@@ -274,14 +304,17 @@ final class RequestPerformerTests: XCTestCase {
             return
         }
         
+        var didExecute = false
         sut.perform(request: request) { result in
+            didExecute = true
             switch result {
             case .success:
                 XCTFail()
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.noResponse)
             }
-        }
+        }.resume()
+        XCTAssertTrue(didExecute)
     }
     
     // MARK: Unit tests for downloadFile

--- a/Tests/EZNetworkingTests/Util/Performers/RequestPerformerTests.swift
+++ b/Tests/EZNetworkingTests/Util/Performers/RequestPerformerTests.swift
@@ -328,14 +328,17 @@ final class RequestPerformerTests: XCTestCase {
                                    urlResponseValidator: MockURLResponseValidator(),
                                    requestDecoder: RequestDecoder())
         
+        var didExecute = false
         sut.downloadFile(url: testURL) { result in
+            didExecute = true
             switch result {
             case .success(let localURL):
                 XCTAssertEqual(localURL.absoluteString, "file:///tmp/test.pdf")
             case .failure:
                 XCTFail()
             }
-        }
+        }.resume()
+        XCTAssertTrue(didExecute)
     }
     
     func testDownloadFileFailsIfValidatorThrowsAnyError() {
@@ -348,14 +351,17 @@ final class RequestPerformerTests: XCTestCase {
                                    urlResponseValidator: validator,
                                    requestDecoder: RequestDecoder())
         
+        var didExecute = false
         sut.downloadFile(url: testURL) { result in
+            didExecute = true
             switch result {
             case .success:
                 XCTFail()
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.conflict)
             }
-        }
+        }.resume()
+        XCTAssertTrue(didExecute)
     }
     
     // MARK: - downloadImage


### PR DESCRIPTION
I noticed the methods in RequestPerformer were calling `resume()` internally. This means that a client has zero control on canceling or suspending a task if they want to once it has started.

> EXAMPLE: on a UITableViewCell, if a cell has an image and user uses `downloadImage()` and user scrolls super fast, once the cell is out of view, the urlSessionDataTask will still be running in background. This is not good for app performance. To optimize, having the ability to call `.cancel()` on the task can reduce app payload.


This PR aims to return `URLSessionDataTask` & `URLSessionDownloadTask` to allow the client more control.
_down sides: more responsibility is placed on client as now they are responsible for running `resume()`_

So this
```
RequestPerformer().perform {
   ...
}
```
can now be done like this
```
let task = RequestPerformer().performTask {
   ...
}
task.resume()

// and if a user wants to cancel the task, they can do this
task.cancel()
```
