### PR TITLE
refactor RequestPerformable return logic

### DIFF
--- a/Sources/EZNetworking/Util/Downloader/FileDownloadable.swift
+++ b/Sources/EZNetworking/Util/Downloader/FileDownloadable.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public protocol FileDownloadable {
     func downloadFile(with url: URL) async throws -> URL
+    @discardableResult
     func downloadFileTask(url: URL, completion: @escaping((Result<URL, NetworkingError>) -> Void)) -> URLSessionDownloadTask
 }
 
@@ -31,8 +32,9 @@ public struct FileDownloader: FileDownloadable {
         }
     }
 
+    @discardableResult
     public func downloadFileTask(url: URL, completion: @escaping((Result<URL, NetworkingError>) -> Void)) -> URLSessionDownloadTask {
-        return urlSession.downloadTask(with: url) { localURL, response, error in
+        let task = urlSession.downloadTask(with: url) { localURL, response, error in
             do {
                 let localURL = try urlResponseValidator.validateDownloadTask(url: localURL, urlResponse: response, error: error)
                 completion(.success(localURL))
@@ -42,5 +44,7 @@ public struct FileDownloader: FileDownloadable {
                 completion(.failure(.unknown))
             }
         }
+        task.resume()
+        return task
     }
 }

--- a/Sources/EZNetworking/Util/Downloader/ImageDownloadable.swift
+++ b/Sources/EZNetworking/Util/Downloader/ImageDownloadable.swift
@@ -3,6 +3,7 @@ import UIKit
 
 public protocol ImageDownloadable {
     func downloadImage(from url: URL) async throws -> UIImage
+    @discardableResult
     func downloadImageTask(url: URL, completion: @escaping((Result<UIImage, NetworkingError>) -> Void)) -> URLSessionDataTask
 }
 
@@ -32,8 +33,9 @@ public struct ImageDownloader: ImageDownloadable {
         }
     }
 
+    @discardableResult
     public func downloadImageTask(url: URL, completion: @escaping((Result<UIImage, NetworkingError>) -> Void)) -> URLSessionDataTask {
-        return urlSession.dataTask(with: url) { data, response, error in
+        let task = urlSession.dataTask(with: url) { data, response, error in
             do {
                 let validData = try self.urlResponseValidator.validate(data: data, urlResponse: response, error: error)
                 let image = try getImage(from: validData)
@@ -44,6 +46,8 @@ public struct ImageDownloader: ImageDownloadable {
                 completion(.failure(.unknown))
             }
         }
+        task.resume()
+        return task
     }
     
     private func getImage(from data: Data) throws -> UIImage {

--- a/Sources/EZNetworking/Util/Performers/RequestPerformer.swift
+++ b/Sources/EZNetworking/Util/Performers/RequestPerformer.swift
@@ -2,9 +2,13 @@ import Foundation
 import UIKit
 
 public protocol RequestPerformable {
+    @discardableResult
     func performTask<T: Decodable>(request: URLRequest, decodeTo decodableObject: T.Type, completion: @escaping((Result<T, NetworkingError>)) -> Void) -> URLSessionDataTask
+    @discardableResult
     func performTask<T: Decodable>(request: Request, decodeTo decodableObject: T.Type, completion: @escaping((Result<T, NetworkingError>)) -> Void) -> URLSessionDataTask
+    @discardableResult
     func performTask(request: URLRequest, completion: @escaping((VoidResult<NetworkingError>) -> Void)) -> URLSessionDataTask
+    @discardableResult
     func performTask(request: Request, completion: @escaping((VoidResult<NetworkingError>) -> Void)) -> URLSessionDataTask
 }
 
@@ -23,8 +27,9 @@ public struct RequestPerformer: RequestPerformable {
     }
     
     // MARK: perform using Completion Handler
+    @discardableResult
     public func performTask<T: Decodable>(request: URLRequest, decodeTo decodableObject: T.Type, completion: @escaping ((Result<T, NetworkingError>)) -> Void) -> URLSessionDataTask {
-        return urlSession.dataTask(with: request) { data, urlResponse, error in
+        let task = urlSession.dataTask(with: request) { data, urlResponse, error in
             do {
                 let validData = try urlResponseValidator.validate(data: data, urlResponse: urlResponse, error: error)
                 let decodedObject = try requestDecoder.decode(decodableObject.self, from: validData)
@@ -37,12 +42,14 @@ public struct RequestPerformer: RequestPerformable {
                 return
             }
         }
+        task.resume()
+        return task
     }
     
     // MARK: perform using Completion Handler and Request protocol
+    @discardableResult
     public func performTask<T: Decodable>(request: Request, decodeTo decodableObject: T.Type, completion: @escaping ((Result<T, NetworkingError>)) -> Void) -> URLSessionDataTask {
-        
-        return urlSession.dataTask(with: request.build()) { data, urlResponse, error in
+        let task = urlSession.dataTask(with: request.build()) { data, urlResponse, error in
             do {
                 let validData = try urlResponseValidator.validate(data: data, urlResponse: urlResponse, error: error)
                 let decodedObject = try requestDecoder.decode(decodableObject.self, from: validData)
@@ -55,12 +62,14 @@ public struct RequestPerformer: RequestPerformable {
                 return
             }
         }
-                                       
+        task.resume()
+        return task
     }
     
     // MARK: perform using Completion Handler without returning Decodable
+    @discardableResult
     public func performTask(request: URLRequest, completion: @escaping ((VoidResult<NetworkingError>) -> Void)) -> URLSessionDataTask {
-        return urlSession.dataTask(with: request) { data, urlResponse, error in
+        let task = urlSession.dataTask(with: request) { data, urlResponse, error in
             do {
                 _ = try urlResponseValidator.validate(data: data, urlResponse: urlResponse, error: error)
                 completion(.success)
@@ -72,11 +81,14 @@ public struct RequestPerformer: RequestPerformable {
                 return
             }
         }
+        task.resume()
+        return task
     }
     
     // MARK: perform using Completion Handler and Request Protocol without returning Decodable
+    @discardableResult
     public func performTask(request: Request, completion: @escaping ((VoidResult<NetworkingError>) -> Void)) -> URLSessionDataTask {
-        return urlSession.dataTask(with: request.build()) { data, urlResponse, error in
+        let task = urlSession.dataTask(with: request.build()) { data, urlResponse, error in
             do {
                 _ = try urlResponseValidator.validate(data: data, urlResponse: urlResponse, error: error)
                 completion(.success)
@@ -88,5 +100,7 @@ public struct RequestPerformer: RequestPerformable {
                 return
             }
         }
+        task.resume()
+        return task
     }
 }

--- a/Tests/EZNetworkingTests/Mocks/MockURLSession.swift
+++ b/Tests/EZNetworkingTests/Mocks/MockURLSession.swift
@@ -103,12 +103,17 @@ class MockURLSessionDataTask: URLSessionDataTask {
 
 class MockURLSessionDownloadTask: URLSessionDownloadTask {
     private let closure: () -> Void
-    
+    var didCancel: Bool = false
+
     init(closure: @escaping () -> Void) {
         self.closure = closure
     }
     
     override func resume() {
         closure()
+    }
+    
+    override func cancel() {
+        didCancel = true
     }
 }

--- a/Tests/EZNetworkingTests/Mocks/MockURLSession.swift
+++ b/Tests/EZNetworkingTests/Mocks/MockURLSession.swift
@@ -86,6 +86,7 @@ class MockURLSession: URLSessionTaskProtocol {
 
 class MockURLSessionDataTask: URLSessionDataTask {
     private let closure: () -> Void
+    var didCancel: Bool = false
     
     init(closure: @escaping () -> Void) {
         self.closure = closure
@@ -93,6 +94,10 @@ class MockURLSessionDataTask: URLSessionDataTask {
     
     override func resume() {
         closure()
+    }
+    
+    override func cancel() {
+        didCancel = true
     }
 }
 

--- a/Tests/EZNetworkingTests/Util/Downloader/FileDownloadableTests.swift
+++ b/Tests/EZNetworkingTests/Util/Downloader/FileDownloadableTests.swift
@@ -92,9 +92,9 @@ final class FileDownloadableTests: XCTestCase {
                                  urlResponseValidator: MockURLResponseValidator(),
                                  requestDecoder: RequestDecoder())
         
-        var didExecute = false
+        let exp = XCTestExpectation()
         sut.downloadFileTask(url: testURL) { result in
-            didExecute = true
+            defer { exp.fulfill() }
             switch result {
             case .success(let localURL):
                 XCTAssertEqual(localURL.absoluteString, "file:///tmp/test.pdf")
@@ -102,7 +102,7 @@ final class FileDownloadableTests: XCTestCase {
                 XCTFail()
             }
         }
-        XCTAssertTrue(didExecute)
+        wait(for: [exp], timeout: 0.1)
     }
     
     func testDownloadFileCanCancel() throws {
@@ -130,9 +130,9 @@ final class FileDownloadableTests: XCTestCase {
                                  urlResponseValidator: validator,
                                  requestDecoder: RequestDecoder())
         
-        var didExecute = false
+        let exp = XCTestExpectation()
         sut.downloadFileTask(url: testURL) { result in
-            didExecute = true
+            defer { exp.fulfill() }
             switch result {
             case .success:
                 XCTFail()
@@ -140,7 +140,7 @@ final class FileDownloadableTests: XCTestCase {
                 XCTAssertEqual(error, NetworkingError.httpError(.conflict))
             }
         }
-        XCTAssertTrue(didExecute)
+        wait(for: [exp], timeout: 0.1)
     }
 
     private func buildResponse(statusCode: Int) -> HTTPURLResponse {

--- a/Tests/EZNetworkingTests/Util/Downloader/FileDownloadableTests.swift
+++ b/Tests/EZNetworkingTests/Util/Downloader/FileDownloadableTests.swift
@@ -101,8 +101,23 @@ final class FileDownloadableTests: XCTestCase {
             case .failure:
                 XCTFail()
             }
-        }.resume()
+        }
         XCTAssertTrue(didExecute)
+    }
+    
+    func testDownloadFileCanCancel() throws {
+        let testURL = URL(string: "https://example.com/example.pdf")!
+        let urlSession = MockURLSession(url: testURL,
+                                        urlResponse: buildResponse(statusCode: 200),
+                                        error: nil)
+        let sut = FileDownloader(urlSession: urlSession,
+                                 urlResponseValidator: MockURLResponseValidator(),
+                                 requestDecoder: RequestDecoder())
+        
+        let task = sut.downloadFileTask(url: testURL) { _ in }
+        task.cancel()
+        let downloadTask = try XCTUnwrap(task as? MockURLSessionDownloadTask)
+        XCTAssertTrue(downloadTask.didCancel)
     }
     
     func testDownloadFileFailsIfValidatorThrowsAnyError() {
@@ -124,7 +139,7 @@ final class FileDownloadableTests: XCTestCase {
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.httpError(.conflict))
             }
-        }.resume()
+        }
         XCTAssertTrue(didExecute)
     }
 

--- a/Tests/EZNetworkingTests/Util/Downloader/ImageDownloadableTests.swift
+++ b/Tests/EZNetworkingTests/Util/Downloader/ImageDownloadableTests.swift
@@ -44,9 +44,9 @@ final class ImageDownloadableTests: XCTestCase {
         let validator = MockURLResponseValidator(throwError: nil)
         let sut = ImageDownloader(urlSession: urlSession, urlResponseValidator: validator)
 
-        var didExecute = false
+        let exp = XCTestExpectation()
         sut.downloadImageTask(url: testURL) { result in
-            didExecute = true
+            defer { exp.fulfill() }
             switch result {
             case .success:
                 XCTAssertTrue(true)
@@ -58,7 +58,7 @@ final class ImageDownloadableTests: XCTestCase {
                 }
             }
         }
-        XCTAssertTrue(didExecute)
+        wait(for: [exp], timeout: 0.1)
     }
     
     func testDownloadImageCanCancel() throws {
@@ -85,17 +85,17 @@ final class ImageDownloadableTests: XCTestCase {
                                   urlResponseValidator: validator,
                                   requestDecoder: RequestDecoder())
 
-        var didExecute = false
+        let exp = XCTestExpectation()
         sut.downloadImageTask(url: testURL) { result in
-            didExecute = true
+            defer { exp.fulfill() }
             switch result {
             case .success:
                 XCTFail()
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.httpError(.conflict))
             }
-        }.resume()
-        XCTAssertTrue(didExecute)
+        }
+        wait(for: [exp], timeout: 0.1)
     }
 
     private func buildResponse(statusCode: Int) -> HTTPURLResponse {

--- a/Tests/EZNetworkingTests/Util/Downloader/ImageDownloadableTests.swift
+++ b/Tests/EZNetworkingTests/Util/Downloader/ImageDownloadableTests.swift
@@ -57,8 +57,22 @@ final class ImageDownloadableTests: XCTestCase {
                     XCTFail()
                 }
             }
-        }.resume()
+        }
         XCTAssertTrue(didExecute)
+    }
+    
+    func testDownloadImageCanCancel() throws {
+        let testURL = URL(string: "https://i.natgeofe.com/n/4f5aaece-3300-41a4-b2a8-ed2708a0a27c/domestic-dog_thumb_square.jpg")!
+        let urlSession = MockURLSession(data: mockPersonJsonData,
+                                        urlResponse: buildResponse(statusCode: 200),
+                                        error: nil)
+        let validator = MockURLResponseValidator(throwError: nil)
+        let sut = ImageDownloader(urlSession: urlSession, urlResponseValidator: validator)
+
+        let task = sut.downloadImageTask(url: testURL) { _ in }
+        task.cancel()
+        let dataTask = try XCTUnwrap(task as? MockURLSessionDataTask)
+        XCTAssertTrue(dataTask.didCancel)
     }
 
     func testDownloadImageFailsWhenValidatorThrowsAnyError() {

--- a/Tests/EZNetworkingTests/Util/Performers/RequestPerformerTests.swift
+++ b/Tests/EZNetworkingTests/Util/Performers/RequestPerformerTests.swift
@@ -24,7 +24,7 @@ final class RequestPerformerTests: XCTestCase {
             case .failure:
                 XCTFail()
             }
-        }.resume()
+        }
         wait(for: [exp], timeout: 0.1)
     }
     
@@ -45,7 +45,7 @@ final class RequestPerformerTests: XCTestCase {
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.httpError(.forbidden))
             }
-        }.resume()
+        }
         wait(for: [exp], timeout: 0.1)
     }
     
@@ -66,7 +66,7 @@ final class RequestPerformerTests: XCTestCase {
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.httpError(.badRequest))
             }
-        }.resume()
+        }
         wait(for: [exp], timeout: 0.1)
     }
     
@@ -87,7 +87,7 @@ final class RequestPerformerTests: XCTestCase {
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.couldNotParse)
             }
-        }.resume()
+        }
         wait(for: [exp], timeout: 0.1)
     }
     
@@ -108,7 +108,7 @@ final class RequestPerformerTests: XCTestCase {
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.noData)
             }
-        }.resume()
+        }
         wait(for: [exp], timeout: 0.1)
     }
     
@@ -129,7 +129,7 @@ final class RequestPerformerTests: XCTestCase {
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.couldNotParse)
             }
-        }.resume()
+        }
         wait(for: [exp], timeout: 0.1)
     }
     
@@ -151,7 +151,7 @@ final class RequestPerformerTests: XCTestCase {
             case .failure:
                 XCTFail()
             }
-        }.resume()
+        }
         wait(for: [exp], timeout: 0.1)
     }
     
@@ -170,7 +170,7 @@ final class RequestPerformerTests: XCTestCase {
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.httpError(.forbidden))
             }
-        }.resume()
+        }
         wait(for: [exp], timeout: 0.1)
     }
     
@@ -189,7 +189,7 @@ final class RequestPerformerTests: XCTestCase {
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.httpError(.badRequest))
             }
-        }.resume()
+        }
         wait(for: [exp], timeout: 0.1)
     }
     
@@ -208,7 +208,7 @@ final class RequestPerformerTests: XCTestCase {
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.couldNotParse)
             }
-        }.resume()
+        }
         wait(for: [exp], timeout: 0.1)
     }
     
@@ -227,7 +227,7 @@ final class RequestPerformerTests: XCTestCase {
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.noData)
             }
-        }.resume()
+        }
         wait(for: [exp], timeout: 0.1)
     }
     
@@ -246,7 +246,7 @@ final class RequestPerformerTests: XCTestCase {
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.couldNotParse)
             }
-        }.resume()
+        }
         wait(for: [exp], timeout: 0.1)
     }
     
@@ -269,7 +269,7 @@ final class RequestPerformerTests: XCTestCase {
             case .failure:
                 XCTFail()
             }
-        }.resume()
+        }
         wait(for: [exp], timeout: 0.1)
     }
     
@@ -290,7 +290,7 @@ final class RequestPerformerTests: XCTestCase {
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.httpError(.forbidden))
             }
-        }.resume()
+        }
         wait(for: [exp], timeout: 0.1)
     }
     
@@ -311,7 +311,7 @@ final class RequestPerformerTests: XCTestCase {
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.httpError(.badRequest))
             }
-        }.resume()
+        }
         wait(for: [exp], timeout: 0.1)
     }
     
@@ -332,7 +332,7 @@ final class RequestPerformerTests: XCTestCase {
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.noData)
             }
-        }.resume()
+        }
         wait(for: [exp], timeout: 0.1)
     }
     
@@ -353,7 +353,7 @@ final class RequestPerformerTests: XCTestCase {
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.noResponse)
             }
-        }.resume()
+        }
         wait(for: [exp], timeout: 0.1)
     }
     
@@ -374,7 +374,7 @@ final class RequestPerformerTests: XCTestCase {
             case .failure:
                 XCTFail()
             }
-        }.resume()
+        }
         wait(for: [exp], timeout: 0.1)
     }
     
@@ -393,7 +393,7 @@ final class RequestPerformerTests: XCTestCase {
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.httpError(.forbidden))
             }
-        }.resume()
+        }
         wait(for: [exp], timeout: 0.1)
     }
     
@@ -412,7 +412,7 @@ final class RequestPerformerTests: XCTestCase {
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.httpError(.badRequest))
             }
-        }.resume()
+        }
         wait(for: [exp], timeout: 0.1)
     }
     
@@ -431,7 +431,7 @@ final class RequestPerformerTests: XCTestCase {
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.noData)
             }
-        }.resume()
+        }
         wait(for: [exp], timeout: 0.1)
     }
     
@@ -450,7 +450,7 @@ final class RequestPerformerTests: XCTestCase {
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.noResponse)
             }
-        }.resume()
+        }
         wait(for: [exp], timeout: 0.1)
     }
     

--- a/Tests/EZNetworkingTests/Util/Performers/RequestPerformerTests.swift
+++ b/Tests/EZNetworkingTests/Util/Performers/RequestPerformerTests.swift
@@ -28,6 +28,20 @@ final class RequestPerformerTests: XCTestCase {
         wait(for: [exp], timeout: 0.1)
     }
     
+    func testPerformWithCompletionHandlerCanCancel() throws {
+        let urlSession = createMockURLSession()
+        let validator = MockURLResponseValidator(throwError: nil)
+        let decoder = RequestDecoder()
+        let sut = RequestPerformer(urlSession: urlSession, urlResponseValidator: validator, requestDecoder: decoder)
+        
+        let request = try XCTUnwrap(sampleUrlRequest, "Failed to create URLRequest")
+        let task = sut.performTask(request: request, decodeTo: Person.self) { _ in }
+        
+        task.cancel()
+        let dataTask = try XCTUnwrap(task as? MockURLSessionDataTask)
+        XCTAssertTrue(dataTask.didCancel)
+    }
+    
     func testPerformWithCompletionHandlerWithErrorFails() throws {
         let urlSession = createMockURLSession(error: HTTPNetworkingError.forbidden)
         let validator = MockURLResponseValidator(throwError: NetworkingError.httpError(.forbidden))
@@ -155,6 +169,18 @@ final class RequestPerformerTests: XCTestCase {
         wait(for: [exp], timeout: 0.1)
     }
     
+    func testPerformWithCompletionHandlerWithRequestProtocolCanCancel() throws {
+        let urlSession = createMockURLSession()
+        let validator = MockURLResponseValidator(throwError: nil)
+        let decoder = RequestDecoder()
+        let sut = RequestPerformer(urlSession: urlSession, urlResponseValidator: validator, requestDecoder: decoder)
+        
+        let task = sut.performTask(request: MockRequest(), decodeTo: Person.self) { _ in }
+        task.cancel()
+        let dataTask = try XCTUnwrap(task as? MockURLSessionDataTask)
+        XCTAssertTrue(dataTask.didCancel)
+    }
+    
     func testPerformWithCompletionHandlerWithRequestProtocolWithErrorFails() {
         let urlSession = createMockURLSession(error: HTTPNetworkingError.forbidden)
         let validator = MockURLResponseValidator(throwError: NetworkingError.httpError(.forbidden))
@@ -273,6 +299,20 @@ final class RequestPerformerTests: XCTestCase {
         wait(for: [exp], timeout: 0.1)
     }
     
+    func testPerformWithCompletionHandlerWithoutDecodableCanCancel() throws {
+        let urlSession = createMockURLSession()
+        let validator = MockURLResponseValidator(throwError: nil)
+        let decoder = RequestDecoder()
+        let sut = RequestPerformer(urlSession: urlSession, urlResponseValidator: validator, requestDecoder: decoder)
+        
+        let request = try XCTUnwrap(sampleUrlRequest, "Failed to create URLRequest")
+        
+        let task = sut.performTask(request: request) { _ in }
+        task.cancel()
+        let dataTask = try XCTUnwrap(task as? MockURLSessionDataTask)
+        XCTAssertTrue(dataTask.didCancel)
+    }
+    
     func testPerformWithCompletionHandlerWithoutDecodableWithErrorFails() throws {
         let urlSession = createMockURLSession(error: NetworkingError.httpError(.forbidden))
         let validator = MockURLResponseValidator(throwError: NetworkingError.httpError(.forbidden))
@@ -376,6 +416,18 @@ final class RequestPerformerTests: XCTestCase {
             }
         }
         wait(for: [exp], timeout: 0.1)
+    }
+    
+    func testPerformWithCompletionHandlerWithoutDecodableWithRequestProtocolCanCancel() throws {
+        let urlSession = createMockURLSession()
+        let validator = MockURLResponseValidator(throwError: nil)
+        let decoder = RequestDecoder()
+        let sut = RequestPerformer(urlSession: urlSession, urlResponseValidator: validator, requestDecoder: decoder)
+        
+        let task = sut.performTask(request: MockRequest()) { _ in }
+        task.cancel()
+        let dataTask = try XCTUnwrap(task as? MockURLSessionDataTask)
+        XCTAssertTrue(dataTask.didCancel)
     }
     
     func testPerformWithCompletionHandlerWithoutDecodableWithRequestProtocolWithErrorFails() {


### PR DESCRIPTION
### What is this PR aiming to achieve?

In an earlier PR, I've refactored `RequestPerformer` various `.perform(...)` methods to return `URLSessionDataTask`. This way, the client can do more complex actions like pause/cancel a data task instead of only being able to execute it.

However, I've noticed this also came with the responsibility for the client to call `.resume()` to initiate the API request. 

```swift
let task = RequestPerformer().perform(...) {
  // handle result
}
task.resume()
```

I wanted to make it easier for users by not needing to remember to call `.resume()` when using `RequestPerformer.perform()` while making API calls but also give them the control to cancel data tasks.

### What's my solution?

Make the RequestPerformer perform method still return the DataTask back to the client, but before returning, call the `.resume()` method, and also mark the method as `@discardableResult` to avoid xcode from throwing warnings.

This same logic was done on `FileDownloadable` and `ImageDownloadable`

##### Example A
A person who just wants to execute an API request
```swift
RequestPerformer().perform(...) {
   // handle result
}
```

##### Example B
A person who want extra control over the dataTask so they can cancel it later if needed
```swift
let task = RequestPerformer().perform(...) {
   // handle result
}

// something happens and user wants to cancel the data task
task.cancel()
```


