### PR TITLE
remove build() method from Request protocol to not expose it to clients

### DIFF
--- a/Sources/EZNetworking/Request/Request.swift
+++ b/Sources/EZNetworking/Request/Request.swift
@@ -7,7 +7,6 @@ public protocol Request {
     var headers: [HTTPHeader]? { get }
     var body: Data? { get }
     var timeoutInterval: TimeInterval { get }
-    var urlRequest: URLRequest? { get }
 }
 
 public extension Request {

--- a/Tests/EZNetworkingTests/Util/Performers/AsyncRequestPerformableTests.swift
+++ b/Tests/EZNetworkingTests/Util/Performers/AsyncRequestPerformableTests.swift
@@ -57,13 +57,6 @@ final class AsyncRequestPerformableTests: XCTestCase {
         }
     }
     
-    func test_PerformAsync_WhenRequestCannotBuildURLRequest_Fails() async throws {
-        let sut = createAsyncRequestPerformer()
-        await XCTAssertThrowsErrorAsync(try await sut.perform(request: MockRequestWithNilBuild(), decodeTo: Person.self)) { error in
-            XCTAssertEqual(error as! NetworkingError, NetworkingError.internalError(.noRequest))
-        }
-    }
-    
     // MARK: Unit test for perform request with Async Await and Request Protocol and return Decodable
 
     func test_PerformAsync_WithoutResponse_Success() async throws {
@@ -112,13 +105,6 @@ final class AsyncRequestPerformableTests: XCTestCase {
         )
         await XCTAssertThrowsErrorAsync(try await sut.perform(request: MockRequest())) { error in
             XCTAssertEqual(error as! NetworkingError, NetworkingError.urlError(URLError(.cannotConnectToHost)))
-        }
-    }
-    
-    func test_PerformAsync_WithoutResponse_WhenRequestCannotBuildURLRequest_Fails() async throws {
-        let sut = createAsyncRequestPerformer()
-        await XCTAssertThrowsErrorAsync(try await sut.perform(request: MockRequestWithNilBuild())) { error in
-            XCTAssertEqual(error as! NetworkingError, NetworkingError.internalError(.noRequest))
         }
     }
 }

--- a/Tests/EZNetworkingTests/Util/Performers/RequestPerformerTests.swift
+++ b/Tests/EZNetworkingTests/Util/Performers/RequestPerformerTests.swift
@@ -134,21 +134,6 @@ final class RequestPerformerTests: XCTestCase {
         wait(for: [exp], timeout: 0.1)
     }
     
-    func test_PerformTask_WhenRequestCannotBuildURLRequest_Fails() {
-        let sut = RequestPerformer()
-        let exp = XCTestExpectation()
-        sut.performTask(request: MockRequestWithNilBuild(), decodeTo: Person.self) { result in
-            defer { exp.fulfill() }
-            switch result {
-            case .success:
-                XCTFail()
-            case .failure(let error):
-                XCTAssertEqual(error, NetworkingError.internalError(.noRequest))
-            }
-        }
-        wait(for: [exp], timeout: 0.1)
-    }
-    
     // MARK: Unit tests for perform using Completion Handler and Requesst Protocol without Decodable response
     
     func test_PerformTask_WithoutDecodable_DoesPass() {
@@ -237,21 +222,6 @@ final class RequestPerformerTests: XCTestCase {
                 XCTFail()
             case .failure(let error):
                 XCTAssertEqual(error, NetworkingError.internalError(.unknown))
-            }
-        }
-        wait(for: [exp], timeout: 0.1)
-    }
-    
-    func test_PerformTask_WithoutDecodable_WhenRequestCannotBuildURLRequest_Fails() {
-        let sut = RequestPerformer()
-        let exp = XCTestExpectation()
-        sut.performTask(request: MockRequestWithNilBuild()) { result in
-            defer { exp.fulfill() }
-            switch result {
-            case .success:
-                XCTFail()
-            case .failure(let error):
-                XCTAssertEqual(error, NetworkingError.internalError(.noRequest))
             }
         }
         wait(for: [exp], timeout: 0.1)


### PR DESCRIPTION
## What's new?

Remove `.build()` method from `Request` protocol to not expose it to clients