### PR TITLE
add url response headers to status codes

### DIFF
--- a/Sources/EZNetworking/Error/NetworkingError.swift
+++ b/Sources/EZNetworking/Error/NetworkingError.swift
@@ -5,10 +5,10 @@ public enum NetworkingError: Error {
     case internalError(InternalError)               /// any internal error
 
     // HTTP Status Code errors
-    case information(HTTPInformationalStatus)       /// 1xx status code errors
-    case redirect(HTTPRedirectionStatus)            /// 3xx status code errors
-    case httpClientError(HTTPClientErrorStatus)     /// 4xx status code errors
-    case httpServerError(HTTPServerErrorStatus)     /// 5xx status code errors
+    case information(HTTPInformationalStatus, URLResponseHeaders)       /// 1xx status code errors
+    case redirect(HTTPRedirectionStatus, URLResponseHeaders)            /// 3xx status code errors
+    case httpClientError(HTTPClientErrorStatus, URLResponseHeaders)     /// 4xx status code errors
+    case httpServerError(HTTPServerErrorStatus, URLResponseHeaders)     /// 5xx status code errors
 
     // URL Errors
     case urlError(URLError)                         /// any URL error
@@ -20,16 +20,16 @@ extension NetworkingError: Equatable {
         case let (.internalError(error1), .internalError(error2)):
             return error1 == error2
         
-        case let (.information(error1), .information(error2)):
+        case let (.information(error1, _), .information(error2, _)):
             return error1 == error2
             
-        case let (.redirect(error1), .redirect(error2)):
+        case let (.redirect(error1, _), .redirect(error2, _)):
             return error1 == error2
 
-        case let (.httpClientError(error1), .httpClientError(error2)):
+        case let (.httpClientError(error1, _), .httpClientError(error2, _)):
             return error1 == error2
         
-        case let (.httpServerError(error1), .httpServerError(error2)):
+        case let (.httpServerError(error1, _), .httpServerError(error2, _)):
             return error1 == error2
 
         case let (.urlError(error), .urlError(error2)):

--- a/Sources/EZNetworking/Validator/ResponseValidator.swift
+++ b/Sources/EZNetworking/Validator/ResponseValidator.swift
@@ -60,7 +60,6 @@ public struct ResponseValidatorImpl: ResponseValidator {
             throw NetworkingError.httpServerError(error, urlResponseHeaders)
         case .unknown:
             throw NetworkingError.internalError(.unknown)
-        
         }
     }
 }

--- a/Sources/EZNetworking/Validator/ResponseValidator.swift
+++ b/Sources/EZNetworking/Validator/ResponseValidator.swift
@@ -45,21 +45,24 @@ public struct ResponseValidatorImpl: ResponseValidator {
 
     private func validateStatusCodeAccepability(from httpURLResponse: HTTPURLResponse) throws {
         let statusCodeType = HTTPStatusCodeType.evaluate(from: httpURLResponse.statusCode)
+        let urlResponseHeaders = httpURLResponse.allHeaderFields
         
         switch statusCodeType {
         case .information(let status):
-            throw NetworkingError.information(status)
-        case .success(let status):
+            throw NetworkingError.information(status, urlResponseHeaders)
+        case .success(_):
             return
         case .redirectionMessage(let status):
-            throw NetworkingError.redirect(status)
+            throw NetworkingError.redirect(status, urlResponseHeaders)
         case .clientSideError(let error):
-            throw NetworkingError.httpClientError(error)
+            throw NetworkingError.httpClientError(error, urlResponseHeaders)
         case .serverSideError(let error):
-            throw NetworkingError.httpServerError(error)
+            throw NetworkingError.httpServerError(error, urlResponseHeaders)
         case .unknown:
             throw NetworkingError.internalError(.unknown)
         
         }
     }
 }
+
+public typealias URLResponseHeaders = [AnyHashable: Any]

--- a/Tests/EZNetworkingTests/Error/InternalError/InternalErrorTests.swift
+++ b/Tests/EZNetworkingTests/Error/InternalError/InternalErrorTests.swift
@@ -36,7 +36,7 @@ final class InternalErrorTestsTests: XCTestCase {
     }
     
     func testRequestFailedIsEquatableWhenErrorIsSame() {
-        let error = NetworkingError.httpClientError(.badRequest)
+        let error = NetworkingError.httpClientError(.badRequest, [:])
         XCTAssertEqual(InternalError.requestFailed(error), InternalError.requestFailed(error))
     }
     

--- a/Tests/EZNetworkingTests/Util/Downloader/FileDownloadableTests.swift
+++ b/Tests/EZNetworkingTests/Util/Downloader/FileDownloadableTests.swift
@@ -31,7 +31,7 @@ final class FileDownloadableTests: XCTestCase {
             urlResponse: buildResponse(statusCode: 200),
             error: nil
         )
-        let validator = MockURLResponseValidator(throwError: NetworkingError.httpClientError(.forbidden))
+        let validator = MockURLResponseValidator(throwError: NetworkingError.httpClientError(.forbidden, [:]))
         let decoder = RequestDecoder()
         let sut = FileDownloader(urlSession: urlSession, validator: validator, requestDecoder: decoder)
         
@@ -39,7 +39,7 @@ final class FileDownloadableTests: XCTestCase {
             _ = try await sut.downloadFile(with: testURL)
             XCTFail("unexpected error")
         } catch let error as NetworkingError {
-            XCTAssertEqual(error, NetworkingError.httpClientError(.forbidden))
+            XCTAssertEqual(error, NetworkingError.httpClientError(.forbidden, [:]))
         }
     }
     
@@ -58,7 +58,7 @@ final class FileDownloadableTests: XCTestCase {
             _ = try await sut.downloadFile(with: testURL)
             XCTFail("unexpected error")
         } catch let error as NetworkingError{
-            XCTAssertEqual(error, NetworkingError.httpClientError(.badRequest))
+            XCTAssertEqual(error, NetworkingError.httpClientError(.badRequest, [:]))
         }
     }
     
@@ -122,7 +122,7 @@ final class FileDownloadableTests: XCTestCase {
     
     func testDownloadFileFailsIfValidatorThrowsAnyError() {
         let testURL = URL(string: "https://example.com/example.pdf")!
-        let validator = MockURLResponseValidator(throwError: NetworkingError.httpClientError(.conflict))
+        let validator = MockURLResponseValidator(throwError: NetworkingError.httpClientError(.conflict, [:]))
         let urlSession = MockURLSession(url: testURL,
                                         urlResponse: buildResponse(statusCode: 200),
                                         error: nil)
@@ -137,7 +137,7 @@ final class FileDownloadableTests: XCTestCase {
             case .success:
                 XCTFail()
             case .failure(let error):
-                XCTAssertEqual(error, NetworkingError.httpClientError(.conflict))
+                XCTAssertEqual(error, NetworkingError.httpClientError(.conflict, [:]))
             }
         }
         wait(for: [exp], timeout: 0.1)

--- a/Tests/EZNetworkingTests/Util/Downloader/ImageDownloadableTests.swift
+++ b/Tests/EZNetworkingTests/Util/Downloader/ImageDownloadableTests.swift
@@ -22,7 +22,7 @@ final class ImageDownloadableTests: XCTestCase {
                                         url: testURL,
                                         urlResponse: buildResponse(statusCode: 200),
                                         error: nil)
-        let validator = MockURLResponseValidator(throwError: NetworkingError.httpClientError(.badRequest))
+        let validator = MockURLResponseValidator(throwError: NetworkingError.httpClientError(.badRequest, [:]))
         let sut = ImageDownloader(urlSession: urlSession,
                                   validator: validator,
                                   requestDecoder: RequestDecoder())
@@ -30,7 +30,7 @@ final class ImageDownloadableTests: XCTestCase {
             _ = try await sut.downloadImage(from: testURL)
             XCTFail()
         } catch let error as NetworkingError {
-            XCTAssertEqual(error, NetworkingError.httpClientError(.badRequest))
+            XCTAssertEqual(error, NetworkingError.httpClientError(.badRequest, [:]))
         }
     }
 
@@ -80,7 +80,7 @@ final class ImageDownloadableTests: XCTestCase {
         let urlSession = MockURLSession(url: testURL,
                                         urlResponse: buildResponse(statusCode: 200),
                                         error: nil)
-        let validator = MockURLResponseValidator(throwError: NetworkingError.httpClientError(.conflict))
+        let validator = MockURLResponseValidator(throwError: NetworkingError.httpClientError(.conflict, [:]))
         let sut = ImageDownloader(urlSession: urlSession,
                                   validator: validator,
                                   requestDecoder: RequestDecoder())
@@ -92,7 +92,7 @@ final class ImageDownloadableTests: XCTestCase {
             case .success:
                 XCTFail()
             case .failure(let error):
-                XCTAssertEqual(error, NetworkingError.httpClientError(.conflict))
+                XCTAssertEqual(error, NetworkingError.httpClientError(.conflict, [:]))
             }
         }
         wait(for: [exp], timeout: 0.1)

--- a/Tests/EZNetworkingTests/Util/Performers/AsyncRequestPerformableTests.swift
+++ b/Tests/EZNetworkingTests/Util/Performers/AsyncRequestPerformableTests.swift
@@ -17,7 +17,7 @@ final class AsyncRequestPerformableTests: XCTestCase {
             urlSession: createMockURLSession(statusCode: 300)
         )
         await XCTAssertThrowsErrorAsync(try await sut.perform(request: MockRequest(), decodeTo: Person.self)) { error in
-            XCTAssertEqual(error as! NetworkingError, NetworkingError.redirect(.multipleChoices))
+            XCTAssertEqual(error as! NetworkingError, NetworkingError.redirect(.multipleChoices, [:]))
         }
     }
     
@@ -26,25 +26,25 @@ final class AsyncRequestPerformableTests: XCTestCase {
             urlSession: createMockURLSession(statusCode: 400)
         )
         await XCTAssertThrowsErrorAsync(try await sut.perform(request: MockRequest(), decodeTo: Person.self)) { error in
-            XCTAssertEqual(error as! NetworkingError, NetworkingError.httpClientError(.badRequest))
+            XCTAssertEqual(error as! NetworkingError, NetworkingError.httpClientError(.badRequest, [:]))
         }
     }
     
     func test_PerformAsync_WhenThereIsError_Fails() async throws {
         let sut = createAsyncRequestPerformer(
-            urlSession: createMockURLSession(error: NetworkingError.httpClientError(.badRequest))
+            urlSession: createMockURLSession(error: NetworkingError.httpClientError(.badRequest, [:]))
         )
         await XCTAssertThrowsErrorAsync(try await sut.perform(request: MockRequest(), decodeTo: Person.self)) { error in
-            XCTAssertEqual(error as! NetworkingError, NetworkingError.httpClientError(.badRequest))
+            XCTAssertEqual(error as! NetworkingError, NetworkingError.httpClientError(.badRequest, [:]))
         }
     }
     
     func test_PerformAsync_WhenThereIsHTTPError_Fails() async throws {
         let sut = createAsyncRequestPerformer(
-            urlSession: createMockURLSession(error: NetworkingError.httpClientError(.forbidden))
+            urlSession: createMockURLSession(error: NetworkingError.httpClientError(.forbidden, [:]))
         )
         await XCTAssertThrowsErrorAsync(try await sut.perform(request: MockRequest(), decodeTo: Person.self)) { error in
-            XCTAssertEqual(error as! NetworkingError, NetworkingError.httpClientError(.forbidden))
+            XCTAssertEqual(error as! NetworkingError, NetworkingError.httpClientError(.forbidden, [:]))
         }
     }
     
@@ -87,7 +87,7 @@ final class AsyncRequestPerformableTests: XCTestCase {
             urlSession: createMockURLSession(statusCode: 300)
         )
         await XCTAssertThrowsErrorAsync(try await sut.perform(request: MockRequest())) { error in
-            XCTAssertEqual(error as! NetworkingError, NetworkingError.redirect(.multipleChoices))
+            XCTAssertEqual(error as! NetworkingError, NetworkingError.redirect(.multipleChoices, [:]))
         }    }
     
     func test_PerformAsync_WithoutResponse_WhenStatusCodeIsNot200_Fails() async throws {
@@ -95,25 +95,25 @@ final class AsyncRequestPerformableTests: XCTestCase {
             urlSession: createMockURLSession(statusCode: 400)
         )
         await XCTAssertThrowsErrorAsync(try await sut.perform(request: MockRequest())) { error in
-            XCTAssertEqual(error as! NetworkingError, NetworkingError.httpClientError(.badRequest))
+            XCTAssertEqual(error as! NetworkingError, NetworkingError.httpClientError(.badRequest, [:]))
         }
     }
     
     func test_PerformAsync_WithoutResponse_WhenThereIsError_Fails() async throws {
         let sut = createAsyncRequestPerformer(
-            urlSession: createMockURLSession(error: NetworkingError.httpClientError(.badRequest))
+            urlSession: createMockURLSession(error: NetworkingError.httpClientError(.badRequest, [:]))
         )
         await XCTAssertThrowsErrorAsync(try await sut.perform(request: MockRequest())) { error in
-            XCTAssertEqual(error as! NetworkingError, NetworkingError.httpClientError(.badRequest))
+            XCTAssertEqual(error as! NetworkingError, NetworkingError.httpClientError(.badRequest, [:]))
         }
     }
     
     func test_PerformAsync_WithoutResponse_WhenThereIsHTTPError_Fails() async throws {
         let sut = createAsyncRequestPerformer(
-            urlSession: createMockURLSession(error: NetworkingError.httpClientError(.forbidden))
+            urlSession: createMockURLSession(error: NetworkingError.httpClientError(.forbidden, [:]))
         )
         await XCTAssertThrowsErrorAsync(try await sut.perform(request: MockRequest())) { error in
-            XCTAssertEqual(error as! NetworkingError, NetworkingError.httpClientError(.forbidden))
+            XCTAssertEqual(error as! NetworkingError, NetworkingError.httpClientError(.forbidden, [:]))
         }
     }
     

--- a/Tests/EZNetworkingTests/Util/Performers/RequestPerformerTests.swift
+++ b/Tests/EZNetworkingTests/Util/Performers/RequestPerformerTests.swift
@@ -42,7 +42,7 @@ final class RequestPerformerTests: XCTestCase {
             case .success:
                 XCTFail()
             case .failure(let error):
-                XCTAssertEqual(error, NetworkingError.redirect(.multipleChoices))
+                XCTAssertEqual(error, NetworkingError.redirect(.multipleChoices, [:]))
             }
         }
         wait(for: [exp], timeout: 0.1)
@@ -59,7 +59,7 @@ final class RequestPerformerTests: XCTestCase {
             case .success:
                 XCTFail()
             case .failure(let error):
-                XCTAssertEqual(error, NetworkingError.httpClientError(.badRequest))
+                XCTAssertEqual(error, NetworkingError.httpClientError(.badRequest, [:]))
             }
         }
         wait(for: [exp], timeout: 0.1)
@@ -170,7 +170,7 @@ final class RequestPerformerTests: XCTestCase {
             case .success:
                 XCTFail()
             case .failure(let error):
-                XCTAssertEqual(error, NetworkingError.redirect(.multipleChoices))
+                XCTAssertEqual(error, NetworkingError.redirect(.multipleChoices, [:]))
             }
         }
         wait(for: [exp], timeout: 0.1)
@@ -187,7 +187,7 @@ final class RequestPerformerTests: XCTestCase {
             case .success:
                 XCTFail()
             case .failure(let error):
-                XCTAssertEqual(error, NetworkingError.httpClientError(.badRequest))
+                XCTAssertEqual(error, NetworkingError.httpClientError(.badRequest, [:]))
             }
         }
         wait(for: [exp], timeout: 0.1)

--- a/Tests/EZNetworkingTests/Validator/ResponseValidatorTests.swift
+++ b/Tests/EZNetworkingTests/Validator/ResponseValidatorTests.swift
@@ -65,7 +65,7 @@ final class URLResponseValidatorTests: XCTestCase {
     
     func test_validateStatus_givenHTTPURLResponseStatusCode100_Throws() throws {
         XCTAssertThrowsError(try sut.validateStatus(from: createHttpUrlResponse(statusCode: 100))) { error in
-            XCTAssertEqual(error as? NetworkingError, NetworkingError.information(.continueStatus))
+            XCTAssertEqual(error as? NetworkingError, NetworkingError.information(.continueStatus, [:]))
         }
     }
     
@@ -75,19 +75,19 @@ final class URLResponseValidatorTests: XCTestCase {
     
     func test_validateStatus_givenHTTPURLResponseStatusCode300_Throws() throws {
         XCTAssertThrowsError(try sut.validateStatus(from: createHttpUrlResponse(statusCode: 300))) { error in
-            XCTAssertEqual(error as? NetworkingError, NetworkingError.redirect(.multipleChoices))
+            XCTAssertEqual(error as? NetworkingError, NetworkingError.redirect(.multipleChoices, [:]))
         }
     }
     
     func test_validateStatus_givenHTTPURLResponseStatusCode400_Throws() throws {
         XCTAssertThrowsError(try sut.validateStatus(from: createHttpUrlResponse(statusCode: 400))) { error in
-            XCTAssertEqual(error as? NetworkingError, NetworkingError.httpClientError(.badRequest))
+            XCTAssertEqual(error as? NetworkingError, NetworkingError.httpClientError(.badRequest, [:]))
         }
     }
     
     func test_validateStatus_givenHTTPURLResponseStatusCode500_Throws() throws {
         XCTAssertThrowsError(try sut.validateStatus(from: createHttpUrlResponse(statusCode: 500))) { error in
-            XCTAssertEqual(error as? NetworkingError, NetworkingError.httpServerError(.internalServerError))
+            XCTAssertEqual(error as? NetworkingError, NetworkingError.httpServerError(.internalServerError, [:]))
         }
     }
 }


### PR DESCRIPTION
## What's new?

Allow for the http url response headers to also be passed back to client so they can handle specific stuff with the headers if they so choose