### PR TITLE
add HTTPBody

### DIFF
--- a/Sources/EZNetworking/HTTP/HTTPBody.swift
+++ b/Sources/EZNetworking/HTTP/HTTPBody.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+public enum HTTPBody {
+    case string(_ str: String)
+    case dictionary(_ dic: Dictionary<String, Any>)
+    case encodable(_ encodable: Encodable)
+    case data(_ data: Data)
+    case fileURL(_ url: URL)
+    case jsonString(_ json: String)
+    case base64(_ base64String: String)
+    case urlComponents(_ components: URLComponents)
+    
+    var data: Data? {
+        switch self {
+        case .string(let string):
+            return string.data(using: .utf8)
+            
+        case .dictionary(let dictionary):
+            do {
+                let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
+                return data
+            } catch {
+                return nil
+            }
+            
+        case .encodable(let encodable):
+            do {
+                let data = try JSONEncoder().encode(encodable)
+                return data
+            } catch {
+                return nil
+            }
+            
+        case .data(let data):
+            return data
+            
+        case .fileURL(let url):
+            do {
+                let data = try Data(contentsOf: url)
+                return data
+            } catch {
+                return nil
+            }
+            
+        case .jsonString(let json):
+            return Data(json.utf8)
+            
+        case .base64(let base64String):
+            if let data = Data(base64Encoded: base64String) {
+                return data
+            } else {
+                return nil
+            }
+            
+        case .urlComponents(let components):
+            guard let query = components.percentEncodedQuery else {
+                return nil
+            }
+            return query.data(using: .utf8)
+        }
+    }
+}

--- a/Sources/EZNetworking/HTTP/HTTPBody.swift
+++ b/Sources/EZNetworking/HTTP/HTTPBody.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 public enum HTTPBody {
+    case none
     case string(_ str: String)
     case dictionary(_ dic: Dictionary<String, Any>)
     case encodable(_ encodable: Encodable)
@@ -12,6 +13,9 @@ public enum HTTPBody {
     
     var data: Data? {
         switch self {
+        case .none:
+            return nil
+
         case .string(let string):
             return string.data(using: .utf8)
             

--- a/Sources/EZNetworking/HTTP/HTTPBody.swift
+++ b/Sources/EZNetworking/HTTP/HTTPBody.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public enum HTTPBody {
     case string(_ str: String)
-    case dictionary(_ dic: Dictionary<String, Any>)
+    case dictionary(_ dic: [String: Any])
     case encodable(_ encodable: Encodable)
     case data(_ data: Data)
     case fileURL(_ url: URL)
@@ -68,10 +68,10 @@ extension HTTPBody: Equatable {
             return str1 == str2
             
         case (.dictionary(let dic1), .dictionary(let dic2)):
-            return true
+            return dictionariesAreEqual(dic1, dic2)
             
         case (.encodable(let encodable1), .encodable(let encodable2)):
-            return String(describing: encodable1) == String(describing: encodable2)  // Compare encoded string representations
+            return String(describing: encodable1) == String(describing: encodable2)
             
         case (.data(let data1), .data(let data2)):
             return data1 == data2
@@ -89,6 +89,16 @@ extension HTTPBody: Equatable {
             return components1 == components2
             
         default:
+            return false
+        }
+    }
+    
+    private static func dictionariesAreEqual(_ dic1: [String: Any], _ dic2: [String: Any]) -> Bool {
+        do {
+            let data1 = try JSONSerialization.data(withJSONObject: dic1, options: [])
+            let data2 = try JSONSerialization.data(withJSONObject: dic2, options: [])
+            return data1 == data2
+        } catch {
             return false
         }
     }

--- a/Sources/EZNetworking/HTTP/HTTPBody.swift
+++ b/Sources/EZNetworking/HTTP/HTTPBody.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 public enum HTTPBody {
-    case none
     case string(_ str: String)
     case dictionary(_ dic: Dictionary<String, Any>)
     case encodable(_ encodable: Encodable)
@@ -13,9 +12,6 @@ public enum HTTPBody {
     
     var data: Data? {
         switch self {
-        case .none:
-            return nil
-
         case .string(let string):
             return string.data(using: .utf8)
             
@@ -61,6 +57,39 @@ public enum HTTPBody {
                 return nil
             }
             return query.data(using: .utf8)
+        }
+    }
+}
+
+extension HTTPBody: Equatable {
+    public static func ==(lhs: HTTPBody, rhs: HTTPBody) -> Bool {
+        switch (lhs, rhs) {
+        case (.string(let str1), .string(let str2)):
+            return str1 == str2
+            
+        case (.dictionary(let dic1), .dictionary(let dic2)):
+            return true
+            
+        case (.encodable(let encodable1), .encodable(let encodable2)):
+            return String(describing: encodable1) == String(describing: encodable2)  // Compare encoded string representations
+            
+        case (.data(let data1), .data(let data2)):
+            return data1 == data2
+            
+        case (.fileURL(let url1), .fileURL(let url2)):
+            return url1 == url2
+            
+        case (.jsonString(let json1), .jsonString(let json2)):
+            return json1 == json2
+            
+        case (.base64(let base64Str1), .base64(let base64Str2)):
+            return base64Str1 == base64Str2
+            
+        case (.urlComponents(let components1), .urlComponents(let components2)):
+            return components1 == components2
+            
+        default:
+            return false
         }
     }
 }

--- a/Sources/EZNetworking/Request/Request.swift
+++ b/Sources/EZNetworking/Request/Request.swift
@@ -5,7 +5,7 @@ public protocol Request {
     var baseUrlString: String { get }
     var parameters: [HTTPParameter]? { get }
     var headers: [HTTPHeader]? { get }
-    var body: Data? { get }
+    var body: HTTPBody? { get }
     var timeoutInterval: TimeInterval { get }
     var cachePolicy: URLRequest.CachePolicy { get }
 }
@@ -21,7 +21,7 @@ public extension Request {
 
         var request = URLRequest(url: url)
         request.httpMethod = httpMethod.rawValue
-        request.httpBody = body
+        request.httpBody = body?.data
         request.timeoutInterval = timeoutInterval
         request.cachePolicy = cachePolicy
 
@@ -42,7 +42,7 @@ internal struct EZRequest: Request {
     var baseUrlString: String
     var parameters: [HTTPParameter]?
     var headers: [HTTPHeader]?
-    var body: Data?
+    var body: HTTPBody?
     var timeoutInterval: TimeInterval
     var cachePolicy: URLRequest.CachePolicy
 }

--- a/Sources/EZNetworking/Request/RequestBuilder.swift
+++ b/Sources/EZNetworking/Request/RequestBuilder.swift
@@ -5,7 +5,7 @@ public protocol RequestBuilder {
     func setBaseUrl(_ baseUrl: String) -> RequestBuilder
     func setParameters(_ parameters: [HTTPParameter]) -> RequestBuilder
     func setHeaders(_ headers: [HTTPHeader]) -> RequestBuilder
-    func setBody(_ body: Data) -> RequestBuilder
+    func setBody(_ body: HTTPBody) -> RequestBuilder
     func setTimeoutInterval(_ timeoutInterval: TimeInterval) -> RequestBuilder
     func setCachePolicy(_ cachePolicy: URLRequest.CachePolicy) -> RequestBuilder
     func build() -> Request?
@@ -16,7 +16,7 @@ public class RequestBuilderImpl: RequestBuilder {
     private var baseUrlString: String?
     private var parameters: [HTTPParameter]?
     private var headers: [HTTPHeader]?
-    private var body: Data?
+    private var body: HTTPBody? = nil
     private var timeoutInterval: TimeInterval?
     private var cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy
 
@@ -49,7 +49,7 @@ public class RequestBuilderImpl: RequestBuilder {
         return self
     }
 
-    public func setBody(_ body: Data) -> RequestBuilder {
+    public func setBody(_ body: HTTPBody) -> RequestBuilder {
         self.body = body
         return self
     }

--- a/Sources/EZNetworking/Request/RequestFactory.swift
+++ b/Sources/EZNetworking/Request/RequestFactory.swift
@@ -5,7 +5,7 @@ public protocol RequestFactory {
                baseUrlString: String,
                parameters: [HTTPParameter]?,
                headers: [HTTPHeader]?,
-               body: Data?,
+               body: HTTPBody?,
                timeoutInterval: TimeInterval,
                cachePolicy: URLRequest.CachePolicy) -> Request
 }
@@ -24,7 +24,7 @@ public class RequestFactoryImpl: RequestFactory {
                baseUrlString: String,
                parameters: [HTTPParameter]?,
                headers: [HTTPHeader]? = nil,
-               body: Data? = nil,
+               body: HTTPBody? = nil,
                timeoutInterval: TimeInterval = 60,
                cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy
     ) -> Request {

--- a/Tests/EZNetworkingTests/HTTP/HTTPBodyTests.swift
+++ b/Tests/EZNetworkingTests/HTTP/HTTPBodyTests.swift
@@ -1,0 +1,129 @@
+import XCTest
+@testable import EZNetworking
+
+class HTTPBodyTests: XCTestCase {
+
+    // MARK: - Test string case
+    func testStringSuccess() {
+        let body = HTTPBody.string("Hello World")
+        let data = body.data
+        
+        XCTAssertNotNil(data)
+        XCTAssertEqual(String(data: data!, encoding: .utf8), "Hello World")
+    }
+    
+    // MARK: - Test dictionary case
+    func testDictionarySuccess() {
+        let dictionary: [String: Any] = ["key": "value"]
+        let body = HTTPBody.dictionary(dictionary)
+        let data = body.data
+        
+        XCTAssertNotNil(data)
+        let decoded = try? JSONSerialization.jsonObject(with: data!, options: []) as? [String: String]
+        XCTAssertEqual(decoded?["key"], "value")
+    }
+    
+    func testDictionarySuccess2() {
+        let dictionary: [String: Any] = ["key": ["subKey": "subValue"]]
+        let body = HTTPBody.dictionary(dictionary)
+        let data = body.data
+        
+        XCTAssertNotNil(data)
+        let decoded = try? JSONSerialization.jsonObject(with: data!, options: []) as? [String: [String: String]]
+        XCTAssertEqual(decoded?["key"], ["subKey": "subValue"])
+    }
+    
+    // MARK: - Test encodable case
+    struct TestEncodable: Codable {
+        let id: Int
+        let name: String
+    }
+    
+    func testEncodableSuccess() {
+        let encodable = TestEncodable(id: 1, name: "Test")
+        let body = HTTPBody.encodable(encodable)
+        let data = body.data
+        
+        XCTAssertNotNil(data)
+        let decoded = try? JSONDecoder().decode(TestEncodable.self, from: data!)
+        XCTAssertEqual(decoded?.id, 1)
+        XCTAssertEqual(decoded?.name, "Test")
+    }
+    
+    // MARK: - Test data case
+    func testDataSuccess() {
+        let data = Data([0x01, 0x02, 0x03])
+        let body = HTTPBody.data(data)
+        
+        XCTAssertEqual(body.data, data)
+    }
+    
+    func testDataFailure() {
+        let body = HTTPBody.data(Data())
+        
+        XCTAssertEqual(body.data, Data())
+    }
+    
+    // MARK: - Test fileURL case
+    
+    func testFileURLFailure() {
+        let fileURL = URL(fileURLWithPath: "/path/to/non/existing/file")
+        let body = HTTPBody.fileURL(fileURL)
+        
+        XCTAssertNil(body.data)
+    }
+    
+    // MARK: - Test jsonString case
+    func testJsonStringSuccess() {
+        let json = "{\"key\":\"value\"}"
+        let body = HTTPBody.jsonString(json)
+        
+        let data = body.data
+        XCTAssertNotNil(data)
+        XCTAssertEqual(String(data: data!, encoding: .utf8), json)
+    }
+    
+    func testJsonStringFailure() {
+        let json = "{\"key\": \"value\""
+        let body = HTTPBody.jsonString(json)
+        
+        XCTAssertNotNil(body.data)
+    }
+    
+    // MARK: - Test base64 case
+    func testBase64Success() {
+        let base64String = "SGVsbG8gV29ybGQ="
+        let body = HTTPBody.base64(base64String)
+        
+        let data = body.data
+        XCTAssertNotNil(data)
+        XCTAssertEqual(String(data: data!, encoding: .utf8), "Hello World")
+    }
+    
+    func testBase64Failure() {
+        let base64String = "InvalidBase64String"
+        let body = HTTPBody.base64(base64String)
+        
+        XCTAssertNil(body.data)
+    }
+    
+    // MARK: - Test urlComponents case
+    func testUrlComponentsSuccess() {
+        var components = URLComponents()
+        components.queryItems = [URLQueryItem(name: "key", value: "value")]
+        
+        let body = HTTPBody.urlComponents(components)
+        let data = body.data
+        
+        XCTAssertNotNil(data)
+        XCTAssertEqual(String(data: data!, encoding: .utf8), "key=value")
+    }
+    
+    func testUrlComponentsFailure() {
+        var components = URLComponents()
+        components.queryItems = nil
+        
+        let body = HTTPBody.urlComponents(components)
+        XCTAssertNil(body.data)
+    }
+}

--- a/Tests/EZNetworkingTests/HTTP/HTTPBodyTests.swift
+++ b/Tests/EZNetworkingTests/HTTP/HTTPBodyTests.swift
@@ -2,10 +2,6 @@ import XCTest
 @testable import EZNetworking
 
 class HTTPBodyTests: XCTestCase {
-    
-    func testNone() {
-        XCTAssertNil(HTTPBody.none.data)
-    }
 
     // MARK: - Test string case
     func testStringSuccess() {

--- a/Tests/EZNetworkingTests/HTTP/HTTPBodyTests.swift
+++ b/Tests/EZNetworkingTests/HTTP/HTTPBodyTests.swift
@@ -2,6 +2,10 @@ import XCTest
 @testable import EZNetworking
 
 class HTTPBodyTests: XCTestCase {
+    
+    func testNone() {
+        XCTAssertNil(HTTPBody.none.data)
+    }
 
     // MARK: - Test string case
     func testStringSuccess() {

--- a/Tests/EZNetworkingTests/HTTP/HTTPBodyTests.swift
+++ b/Tests/EZNetworkingTests/HTTP/HTTPBodyTests.swift
@@ -126,4 +126,72 @@ class HTTPBodyTests: XCTestCase {
         let body = HTTPBody.urlComponents(components)
         XCTAssertNil(body.data)
     }
+    
+    func testStringEquality() {
+        let body1 = HTTPBody.string("testString")
+        let body2 = HTTPBody.string("testString")
+        let body3 = HTTPBody.string("differentString")
+        
+        XCTAssertTrue(body1 == body2)
+        XCTAssertFalse(body1 == body3)
+    }
+    
+    func testDictionaryEquality() {
+        let dictionary1: [String: Any] = ["key1": "value1", "key2": 2]
+        let dictionary2: [String: Any] = ["key1": "value1", "key2": 3]
+        
+        let body1 = HTTPBody.dictionary(dictionary1)
+        let body2 = HTTPBody.dictionary(dictionary2)
+        
+        XCTAssertFalse(body1 == body2)
+    }
+    
+    func testEncodableEquality() {
+        struct TestEncodable: Codable, Equatable {
+            let id: Int
+            let name: String
+        }
+        
+        let encodable1 = TestEncodable(id: 1, name: "Test")
+        let encodable2 = TestEncodable(id: 1, name: "Test")
+        let encodable3 = TestEncodable(id: 2, name: "Test")
+        
+        let body1 = HTTPBody.encodable(encodable1)
+        let body2 = HTTPBody.encodable(encodable2)
+        let body3 = HTTPBody.encodable(encodable3)
+        
+        XCTAssertTrue(body1 == body2)
+        XCTAssertFalse(body1 == body3)
+    }
+    
+    // Test for .data case
+    func testDataEquality() {
+        let data1 = Data([0x01, 0x02, 0x03])
+        let data2 = Data([0x01, 0x02, 0x03])
+        let data3 = Data([0x01, 0x02, 0x04])
+        
+        let body1 = HTTPBody.data(data1)
+        let body2 = HTTPBody.data(data2)
+        let body3 = HTTPBody.data(data3)
+        
+        XCTAssertTrue(body1 == body2)
+        XCTAssertFalse(body1 == body3)
+    }
+    
+    func testMixedCaseEquality() {
+        let stringBody = HTTPBody.string("testString")
+        let dictionaryBody: [String: Any] = ["key": "value"]
+        let body1 = HTTPBody.dictionary(dictionaryBody)
+        
+        XCTAssertFalse(stringBody == body1)
+    }
+    
+    func testDataEqualityNil() {
+        let body1 = HTTPBody.data(Data([0x01, 0x02, 0x03]))
+        let body2 = HTTPBody.data(Data([0x01, 0x02, 0x03]))
+        
+        XCTAssertTrue(body1 == body2)
+        let body3 = HTTPBody.data(Data())
+        XCTAssertFalse(body1 == body3)
+    }
 }

--- a/Tests/EZNetworkingTests/Request/RequestBuilderTests.swift
+++ b/Tests/EZNetworkingTests/Request/RequestBuilderTests.swift
@@ -15,7 +15,7 @@ final class RequestBuilderTests: XCTestCase {
             HTTPHeader.contentType(.json),
             HTTPHeader.authorization(.bearer("token"))
         ]
-        let body = "{\"name\": \"John\"}".data(using: .utf8)!
+        let body = HTTPBody.jsonString("{\"name\": \"John\"}")
         let timeoutInterval: TimeInterval = 30
         
         let request = builder

--- a/Tests/EZNetworkingTests/Request/RequestFactoryTests.swift
+++ b/Tests/EZNetworkingTests/Request/RequestFactoryTests.swift
@@ -15,7 +15,7 @@ final class RequestFactoryTests: XCTestCase {
             HTTPHeader.contentType(.json),
             HTTPHeader.authorization(.bearer("token"))
         ]
-        let body = "{\"name\": \"John\"}".data(using: .utf8)
+        let body = HTTPBody.jsonString("{\"name\": \"John\"}")
         let timeoutInterval: TimeInterval = 30
         
         let request = builder.build(httpMethod: httpMethod,
@@ -44,14 +44,14 @@ final class RequestFactoryTests: XCTestCase {
                                     baseUrlString: urlString,
                                     parameters: nil,
                                     headers: nil,
-                                    body: nil,
+                                    body: .none,
                                     timeoutInterval: 60)
         
         XCTAssertNotNil(request)
         XCTAssertEqual(request.baseUrlString, "https://example.com/api")
         XCTAssertEqual(request.httpMethod, httpMethod)
         XCTAssertNil(request.parameters)
-        XCTAssertNil(request.body)
+        XCTAssertEqual(request.body, .none)
         XCTAssertEqual(request.timeoutInterval, 60)
         XCTAssertNil(request.headers)
         XCTAssertEqual(request.cachePolicy, .useProtocolCachePolicy)

--- a/Tests/EZNetworkingTests/Request/RequestFactoryTests.swift
+++ b/Tests/EZNetworkingTests/Request/RequestFactoryTests.swift
@@ -44,14 +44,14 @@ final class RequestFactoryTests: XCTestCase {
                                     baseUrlString: urlString,
                                     parameters: nil,
                                     headers: nil,
-                                    body: .none,
+                                    body: nil,
                                     timeoutInterval: 60)
         
         XCTAssertNotNil(request)
         XCTAssertEqual(request.baseUrlString, "https://example.com/api")
         XCTAssertEqual(request.httpMethod, httpMethod)
         XCTAssertNil(request.parameters)
-        XCTAssertEqual(request.body, .none)
+        XCTAssertNil(request.body)
         XCTAssertEqual(request.timeoutInterval, 60)
         XCTAssertNil(request.headers)
         XCTAssertEqual(request.cachePolicy, .useProtocolCachePolicy)

--- a/Tests/EZNetworkingTests/Request/RequestTests.swift
+++ b/Tests/EZNetworkingTests/Request/RequestTests.swift
@@ -92,8 +92,8 @@ private struct MockRequest: Request {
         ]
     }
     
-    var body: Data? {
-        "{\"name\": \"John\"}".data(using: .utf8)
+    var body: EZNetworking.HTTPBody? {
+        .jsonString("{\"name\": \"John\"}")
     }
     
     var cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy

--- a/Tests/EZNetworkingTests/Util/Performers/AsyncRequestPerformableTests.swift
+++ b/Tests/EZNetworkingTests/Util/Performers/AsyncRequestPerformableTests.swift
@@ -175,7 +175,7 @@ private struct MockRequest: Request {
     var baseUrlString: String { "https://www.example.com" }
     var parameters: [HTTPParameter]? { nil }
     var headers: [HTTPHeader]? { nil }
-    var body: Data? { nil }
+    var body: HTTPBody? { nil }
 }
 
 private struct MockRequestWithNilBuild: Request {
@@ -183,6 +183,6 @@ private struct MockRequestWithNilBuild: Request {
     var baseUrlString: String { "https://www.example.com" }
     var parameters: [HTTPParameter]? { nil }
     var headers: [HTTPHeader]? { nil }
-    var body: Data? { nil }
+    var body: HTTPBody? { nil }
     var urlRequest: URLRequest? { nil }
 }

--- a/Tests/EZNetworkingTests/Util/Performers/RequestPerformerTests.swift
+++ b/Tests/EZNetworkingTests/Util/Performers/RequestPerformerTests.swift
@@ -277,7 +277,7 @@ private struct MockRequest: Request {
     var baseUrlString: String { "https://www.example.com" }
     var parameters: [HTTPParameter]? { nil }
     var headers: [HTTPHeader]? { nil }
-    var body: Data? { nil }
+    var body: HTTPBody? { nil }
 }
 
 private struct MockRequestWithNilBuild: Request {
@@ -285,6 +285,6 @@ private struct MockRequestWithNilBuild: Request {
     var baseUrlString: String { "https://www.example.com" }
     var parameters: [HTTPParameter]? { nil }
     var headers: [HTTPHeader]? { nil }
-    var body: Data? { nil }
+    var body: HTTPBody? { nil }
     var urlRequest: URLRequest? { nil }
 }


### PR DESCRIPTION
## What's new?

Refactor `Request.body` to use new type `HTTPBody` instead of `Data`.

```swift
public enum HTTPBody {
    case string(_ str: String)
    case dictionary(_ dic: Dictionary<String, Any>)
    case encodable(_ encodable: Encodable)
    case data(_ data: Data)
    case fileURL(_ url: URL)
    case jsonString(_ json: String)
    case base64(_ base64String: String)
    case urlComponents(_ components: URLComponents)
    
    var data: Data? { 
        // ...implementation converting each case into Data
    }
}
```