### PR TITLE
Improve test speed + minor refactors

### DIFF
--- a/Sources/EZNetworking/Error/InternalError/InternalError.swift
+++ b/Sources/EZNetworking/Error/InternalError/InternalError.swift
@@ -10,6 +10,7 @@ public enum InternalError: Error {
     case noRequest
     case noHTTPURLResponse
     case invalidImageData
+    case lostReferenceOfSelf
     case unknown
 }
 
@@ -24,7 +25,8 @@ extension InternalError: Equatable {
             (.noResponse, .noResponse),
             (.noRequest, .noRequest),
             (.noHTTPURLResponse, .noHTTPURLResponse),
-            (.invalidImageData, .invalidImageData):
+            (.invalidImageData, .invalidImageData),
+            (.lostReferenceOfSelf, .lostReferenceOfSelf):
             return true
             
         case let (.requestFailed(lhsError), .requestFailed(rhsError)):

--- a/Sources/EZNetworking/Util/Downloader/ImageDownloadable.swift
+++ b/Sources/EZNetworking/Util/Downloader/ImageDownloadable.swift
@@ -7,12 +7,12 @@ public protocol ImageDownloadable {
     func downloadImageTask(url: URL, completion: @escaping((Result<UIImage, NetworkingError>) -> Void)) -> URLSessionDataTask
 }
 
-public struct ImageDownloader: ImageDownloadable {
+public class ImageDownloader: ImageDownloadable {
     private let urlSession: URLSessionTaskProtocol
     private let validator: ResponseValidator
     private let requestDecoder: RequestDecodable
     
-    public init(sessionConfiguration: URLSessionConfiguration = .default,
+    public convenience init(sessionConfiguration: URLSessionConfiguration = .default,
                 sessionDelegate: SessionDelegate = SessionDelegate(),
                 delegateQueue: OperationQueue? = nil,
                 validator: ResponseValidator = ResponseValidatorImpl(),
@@ -55,11 +55,11 @@ public struct ImageDownloader: ImageDownloadable {
     public func downloadImageTask(url: URL, completion: @escaping((Result<UIImage, NetworkingError>) -> Void)) -> URLSessionDataTask {
         let task = urlSession.dataTask(with: url) { data, response, error in
             do {
-                try validator.validateNoError(error)
-                try validator.validateStatus(from: response)
-                let validData = try validator.validateData(data)
+                try self.validator.validateNoError(error)
+                try self.validator.validateStatus(from: response)
+                let validData = try self.validator.validateData(data)
                 
-                let image = try getImage(from: validData)
+                let image = try self.getImage(from: validData)
                 completion(.success(image))
             } catch let networkError as NetworkingError {
                 completion(.failure(networkError))
@@ -71,7 +71,7 @@ public struct ImageDownloader: ImageDownloadable {
         return task
     }
     
-    private func getImage(from data: Data) throws -> UIImage {
+    internal func getImage(from data: Data) throws -> UIImage {
         guard let image = UIImage(data: data) else {
             throw NetworkingError.internalError(.invalidImageData)
         }

--- a/Sources/EZNetworking/Util/Downloader/ImageDownloadable.swift
+++ b/Sources/EZNetworking/Util/Downloader/ImageDownloadable.swift
@@ -53,7 +53,11 @@ public class ImageDownloader: ImageDownloadable {
 
     @discardableResult
     public func downloadImageTask(url: URL, completion: @escaping((Result<UIImage, NetworkingError>) -> Void)) -> URLSessionDataTask {
-        let task = urlSession.dataTask(with: url) { data, response, error in
+        let task = urlSession.dataTask(with: url) { [weak self] data, response, error in
+            guard let self else {
+                completion(.failure(.internalError(.lostReferenceOfSelf)))
+                return
+            }
             do {
                 try self.validator.validateNoError(error)
                 try self.validator.validateStatus(from: response)

--- a/Tests/EZNetworkingTests/Decoding/RequestDecoderTests.swift
+++ b/Tests/EZNetworkingTests/Decoding/RequestDecoderTests.swift
@@ -6,7 +6,7 @@ final class RequestDecoderTests: XCTestCase {
     func testDocoderCanDocodeMockJSONIntoDeocdableObject() throws {
         let sut = RequestDecoder()
         do {
-            let person = try sut.decode(Person.self, from: mockPersonJsonData)
+            let person = try sut.decode(Person.self, from: MockData.mockPersonJsonData)
             XCTAssertEqual(person.name, "John")
             XCTAssertEqual(person.age, 30)
         } catch {
@@ -17,7 +17,7 @@ final class RequestDecoderTests: XCTestCase {
     func testDocoderCanNotDocodeInvalidMockJSONIntoDeocdableObject() throws {
         let sut = RequestDecoder()
         do {
-            _ = try sut.decode(Person.self, from: invalidMockPersonJsonData)
+            _ = try sut.decode(Person.self, from: MockData.invalidMockPersonJsonData)
             XCTFail("Unexpected error)")
         } catch let error as NetworkingError {
             XCTAssertEqual(error, NetworkingError.internalError(.couldNotParse))

--- a/Tests/EZNetworkingTests/Error/InternalError/InternalErrorTests.swift
+++ b/Tests/EZNetworkingTests/Error/InternalError/InternalErrorTests.swift
@@ -40,6 +40,10 @@ final class InternalErrorTestsTests: XCTestCase {
         XCTAssertEqual(InternalError.requestFailed(error), InternalError.requestFailed(error))
     }
     
+    func testLostReferenceOfSelfsEquatable() {
+        XCTAssertEqual(InternalError.lostReferenceOfSelf, InternalError.lostReferenceOfSelf)
+    }
+    
     func testUnknownIsEquatable() {
         XCTAssertEqual(InternalError.unknown, InternalError.unknown)
     }

--- a/Tests/EZNetworkingTests/Mocks/Mock-Codeable.swift
+++ b/Tests/EZNetworkingTests/Mocks/Mock-Codeable.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct Person: Decodable {
+struct Person: Codable {
     var name: String
     var age: Int
 }

--- a/Tests/EZNetworkingTests/Mocks/Mock-JSON.swift
+++ b/Tests/EZNetworkingTests/Mocks/Mock-JSON.swift
@@ -1,15 +1,24 @@
 import Foundation
+@testable import EZNetworking
 
-let mockPersonJsonData: Data = """
-{
-    "name": "John",
-    "age": 30
+struct MockData {
+    static var mockPersonJsonData: Data {
+        let jsonString = """
+        {
+            "name": "John",
+            "age": 30
+        }
+        """
+        return HTTPBody.jsonString(jsonString).data!
+    }
+    
+    static var invalidMockPersonJsonData: Data {
+        let jsonString = """
+        {
+            "Name": "John",
+            "Age": 30
+        }
+        """
+        return HTTPBody.jsonString(jsonString).data!
+    }
 }
-""".data(using: .utf8)!
-
-let invalidMockPersonJsonData: Data = """
-{
-    "Name": "John",
-    "Age": 30
-}
-""".data(using: .utf8)!

--- a/Tests/EZNetworkingTests/Mocks/Mock-JSON.swift
+++ b/Tests/EZNetworkingTests/Mocks/Mock-JSON.swift
@@ -21,4 +21,16 @@ struct MockData {
         """
         return HTTPBody.jsonString(jsonString).data!
     }
+    
+    static func imageUrlData(from imageUrlString: String) -> Data? {
+        guard let url = URL(string: imageUrlString) else {
+            return nil
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            return data
+        } catch {
+            return nil
+        }
+    }
 }

--- a/Tests/EZNetworkingTests/Mocks/MockURLSession.swift
+++ b/Tests/EZNetworkingTests/Mocks/MockURLSession.swift
@@ -60,10 +60,10 @@ class MockURLSession: URLSessionTaskProtocol {
         }
         self.url = url
         
-        guard let data, let url = self.url else {
+        guard let data, let url = self.url, let urlResponse else {
             throw NetworkingError.internalError(.unknown)
         }
-        return (data, URLResponse(url: url, mimeType: nil, expectedContentLength: 0, textEncodingName: nil))
+        return (data, urlResponse)
     }
     
     func downloadTask(with url: URL, completionHandler: @escaping @Sendable (URL?, URLResponse?, Error?) -> Void) -> URLSessionDownloadTask {

--- a/Tests/EZNetworkingTests/Util/Downloader/ImageDownloadableTests.swift
+++ b/Tests/EZNetworkingTests/Util/Downloader/ImageDownloadableTests.swift
@@ -107,7 +107,7 @@ final class ImageDownloadableTests: XCTestCase {
     }
 
     private func buildResponse(statusCode: Int) -> HTTPURLResponse {
-        HTTPURLResponse(url: URL(string: "https://example.com")!,
+        HTTPURLResponse(url: URL(string: imageUrlString)!,
                         statusCode: statusCode,
                         httpVersion: nil,
                         headerFields: nil)!

--- a/Tests/EZNetworkingTests/Util/Downloader/ImageDownloadableTests.swift
+++ b/Tests/EZNetworkingTests/Util/Downloader/ImageDownloadableTests.swift
@@ -18,7 +18,7 @@ final class ImageDownloadableTests: XCTestCase {
 
     func testDownloadImageFails() async throws {
         let testURL = URL(string: "https://i.natgeofe.com/n/4f5aaece-3300-41a4-b2a8-ed2708a0a27c/domestic-dog_thumb_square.jpg")!
-        let urlSession = MockURLSession(data: mockPersonJsonData,
+        let urlSession = MockURLSession(data: MockData.mockPersonJsonData,
                                         url: testURL,
                                         urlResponse: buildResponse(statusCode: 200),
                                         error: nil)
@@ -38,7 +38,7 @@ final class ImageDownloadableTests: XCTestCase {
 
     func testDownloadImageSuccess() {
         let testURL = URL(string: "https://i.natgeofe.com/n/4f5aaece-3300-41a4-b2a8-ed2708a0a27c/domestic-dog_thumb_square.jpg")!
-        let urlSession = MockURLSession(data: mockPersonJsonData,
+        let urlSession = MockURLSession(data: MockData.mockPersonJsonData,
                                         urlResponse: buildResponse(statusCode: 200),
                                         error: nil)
         let validator = MockURLResponseValidator()
@@ -63,7 +63,7 @@ final class ImageDownloadableTests: XCTestCase {
     
     func testDownloadImageCanCancel() throws {
         let testURL = URL(string: "https://i.natgeofe.com/n/4f5aaece-3300-41a4-b2a8-ed2708a0a27c/domestic-dog_thumb_square.jpg")!
-        let urlSession = MockURLSession(data: mockPersonJsonData,
+        let urlSession = MockURLSession(data: MockData.mockPersonJsonData,
                                         urlResponse: buildResponse(statusCode: 200),
                                         error: nil)
         let validator = MockURLResponseValidator()

--- a/Tests/EZNetworkingTests/Util/Downloader/ImageDownloadableTests.swift
+++ b/Tests/EZNetworkingTests/Util/Downloader/ImageDownloadableTests.swift
@@ -8,7 +8,7 @@ final class ImageDownloadableTests: XCTestCase {
     }
     
     // MARK: test Async/Await
-
+    
     func testDownloadImageSuccess() async throws {
         let testURL = URL(string: imageUrlString)!
         let urlSession = MockURLSession(data: Data(),

--- a/Tests/EZNetworkingTests/Util/Downloader/ImageDownloadableTests.swift
+++ b/Tests/EZNetworkingTests/Util/Downloader/ImageDownloadableTests.swift
@@ -3,10 +3,14 @@ import XCTest
 
 final class ImageDownloadableTests: XCTestCase {
     
+    private var imageUrlString: String {
+        "https://i.natgeofe.com/n/4f5aaece-3300-41a4-b2a8-ed2708a0a27c/domestic-dog_thumb_square.jpg"
+    }
+    
     // MARK: test Async/Await
     
     func testDownloadImageSuccess() async throws { // note: this is an async test as it actually decodes url to generate the image
-        let testURL = URL(string: "https://i.natgeofe.com/n/4f5aaece-3300-41a4-b2a8-ed2708a0a27c/domestic-dog_thumb_square.jpg")!
+        let testURL = URL(string: imageUrlString)!
         let sut = ImageDownloader(urlSession: URLSession.shared)
         do {
             _ = try await sut.downloadImage(from: testURL)
@@ -17,7 +21,7 @@ final class ImageDownloadableTests: XCTestCase {
     }
 
     func testDownloadImageFails() async throws {
-        let testURL = URL(string: "https://i.natgeofe.com/n/4f5aaece-3300-41a4-b2a8-ed2708a0a27c/domestic-dog_thumb_square.jpg")!
+        let testURL = URL(string: imageUrlString)!
         let urlSession = MockURLSession(data: MockData.mockPersonJsonData,
                                         url: testURL,
                                         urlResponse: buildResponse(statusCode: 200),
@@ -37,7 +41,7 @@ final class ImageDownloadableTests: XCTestCase {
     // MARK: - test callbacks
 
     func testDownloadImageSuccess() {
-        let testURL = URL(string: "https://i.natgeofe.com/n/4f5aaece-3300-41a4-b2a8-ed2708a0a27c/domestic-dog_thumb_square.jpg")!
+        let testURL = URL(string: imageUrlString)!
         let urlSession = MockURLSession(data: MockData.mockPersonJsonData,
                                         urlResponse: buildResponse(statusCode: 200),
                                         error: nil)
@@ -62,7 +66,7 @@ final class ImageDownloadableTests: XCTestCase {
     }
     
     func testDownloadImageCanCancel() throws {
-        let testURL = URL(string: "https://i.natgeofe.com/n/4f5aaece-3300-41a4-b2a8-ed2708a0a27c/domestic-dog_thumb_square.jpg")!
+        let testURL = URL(string: imageUrlString)!
         let urlSession = MockURLSession(data: MockData.mockPersonJsonData,
                                         urlResponse: buildResponse(statusCode: 200),
                                         error: nil)
@@ -76,7 +80,7 @@ final class ImageDownloadableTests: XCTestCase {
     }
 
     func testDownloadImageFailsWhenValidatorThrowsAnyError() {
-        let testURL = URL(string: "https://i.natgeofe.com/n/4f5aaece-3300-41a4-b2a8-ed2708a0a27c/domestic-dog_thumb_square.jpg")!
+        let testURL = URL(string: imageUrlString)!
         let urlSession = MockURLSession(url: testURL,
                                         urlResponse: buildResponse(statusCode: 200),
                                         error: nil)

--- a/Tests/EZNetworkingTests/Util/Downloader/ImageDownloadableTests.swift
+++ b/Tests/EZNetworkingTests/Util/Downloader/ImageDownloadableTests.swift
@@ -8,7 +8,7 @@ final class ImageDownloadableTests: XCTestCase {
     }
     
     // MARK: test Async/Await
-    
+
     func testDownloadImageSuccess() async throws {
         let testURL = URL(string: imageUrlString)!
         let urlSession = MockURLSession(data: Data(),

--- a/Tests/EZNetworkingTests/Util/Downloader/ImageDownloadableTests.swift
+++ b/Tests/EZNetworkingTests/Util/Downloader/ImageDownloadableTests.swift
@@ -9,9 +9,15 @@ final class ImageDownloadableTests: XCTestCase {
     
     // MARK: test Async/Await
     
-    func testDownloadImageSuccess() async throws { // note: this is an async test as it actually decodes url to generate the image
+    func testDownloadImageSuccess() async throws {
         let testURL = URL(string: imageUrlString)!
-        let sut = ImageDownloader(urlSession: URLSession.shared)
+        let data = try XCTUnwrap(MockData.imageUrlData(from: imageUrlString),
+                                 "Was not able to convert image url into data")
+        let urlSession = MockURLSession(data: data,
+                                        url: testURL,
+                                        urlResponse: buildResponse(statusCode: 200),
+                                        error: nil)
+        let sut = ImageDownloader(urlSession: urlSession)
         do {
             _ = try await sut.downloadImage(from: testURL)
             XCTAssertTrue(true)

--- a/Tests/EZNetworkingTests/Util/Downloader/ImageDownloadableTests.swift
+++ b/Tests/EZNetworkingTests/Util/Downloader/ImageDownloadableTests.swift
@@ -11,13 +11,11 @@ final class ImageDownloadableTests: XCTestCase {
     
     func testDownloadImageSuccess() async throws {
         let testURL = URL(string: imageUrlString)!
-        let data = try XCTUnwrap(MockData.imageUrlData(from: imageUrlString),
-                                 "Was not able to convert image url into data")
-        let urlSession = MockURLSession(data: data,
+        let urlSession = MockURLSession(data: Data(),
                                         url: testURL,
                                         urlResponse: buildResponse(statusCode: 200),
                                         error: nil)
-        let sut = ImageDownloader(urlSession: urlSession)
+        let sut = SpyImageDownloader(urlSession: urlSession)
         do {
             _ = try await sut.downloadImage(from: testURL)
             XCTAssertTrue(true)
@@ -28,7 +26,7 @@ final class ImageDownloadableTests: XCTestCase {
 
     func testDownloadImageFails() async throws {
         let testURL = URL(string: imageUrlString)!
-        let urlSession = MockURLSession(data: MockData.mockPersonJsonData,
+        let urlSession = MockURLSession(data: Data(),
                                         url: testURL,
                                         urlResponse: buildResponse(statusCode: 200),
                                         error: nil)
@@ -48,7 +46,7 @@ final class ImageDownloadableTests: XCTestCase {
 
     func testDownloadImageSuccess() {
         let testURL = URL(string: imageUrlString)!
-        let urlSession = MockURLSession(data: MockData.mockPersonJsonData,
+        let urlSession = MockURLSession(data: Data(),
                                         urlResponse: buildResponse(statusCode: 200),
                                         error: nil)
         let validator = MockURLResponseValidator()
@@ -73,7 +71,7 @@ final class ImageDownloadableTests: XCTestCase {
     
     func testDownloadImageCanCancel() throws {
         let testURL = URL(string: imageUrlString)!
-        let urlSession = MockURLSession(data: MockData.mockPersonJsonData,
+        let urlSession = MockURLSession(data: Data(),
                                         urlResponse: buildResponse(statusCode: 200),
                                         error: nil)
         let validator = MockURLResponseValidator()
@@ -113,5 +111,11 @@ final class ImageDownloadableTests: XCTestCase {
                         statusCode: statusCode,
                         httpVersion: nil,
                         headerFields: nil)!
+    }
+}
+
+private class SpyImageDownloader: ImageDownloader {
+    override func getImage(from data: Data) throws -> UIImage {
+        return UIImage(systemName: "circle")!
     }
 }

--- a/Tests/EZNetworkingTests/Util/Performers/AsyncRequestPerformableTests.swift
+++ b/Tests/EZNetworkingTests/Util/Performers/AsyncRequestPerformableTests.swift
@@ -59,7 +59,7 @@ final class AsyncRequestPerformableTests: XCTestCase {
     
     func test_PerformAsync_WhenDataCannotBeDecodedToType_Fails() async throws {
         let sut = createAsyncRequestPerformer(
-            urlSession: createMockURLSession(data: invalidMockPersonJsonData)
+            urlSession: createMockURLSession(data: MockData.invalidMockPersonJsonData)
         )
         await XCTAssertThrowsErrorAsync(try await sut.perform(request: MockRequest(), decodeTo: Person.self)) { error in
             XCTAssertEqual(error as! NetworkingError, NetworkingError.internalError(.couldNotParse))
@@ -128,7 +128,7 @@ final class AsyncRequestPerformableTests: XCTestCase {
     
     func test_PerformAsync_WithoutResponse_WhenDataCannotBeDecodedToTypeEvenThoughDataWillNotBeDecoded_Succeeds() async throws {
         let sut = createAsyncRequestPerformer(
-            urlSession: createMockURLSession(data: invalidMockPersonJsonData)
+            urlSession: createMockURLSession(data: MockData.invalidMockPersonJsonData)
         )
         _ = try await sut.perform(request: MockRequest())
     }
@@ -152,7 +152,7 @@ private func createAsyncRequestPerformer(
 }
 
 private func createMockURLSession(
-    data: Data? = mockPersonJsonData,
+    data: Data? = MockData.mockPersonJsonData,
     statusCode: Int = 200,
     error: Error? = nil
 ) -> MockURLSession {

--- a/Tests/EZNetworkingTests/Util/Performers/RequestPerformerTests.swift
+++ b/Tests/EZNetworkingTests/Util/Performers/RequestPerformerTests.swift
@@ -66,7 +66,7 @@ final class RequestPerformerTests: XCTestCase {
     
     func test_PerformTask_WhenDataIsInvalid_Fails() {
         let sut = createRequestPerformer(
-            urlSession: createMockURLSession(data: invalidMockPersonJsonData)
+            urlSession: createMockURLSession(data: MockData.invalidMockPersonJsonData)
         )
         
         let exp = XCTestExpectation()
@@ -194,7 +194,7 @@ final class RequestPerformerTests: XCTestCase {
     
     func test_PerformTask_WithoutDecodable_WhenDataIsInvalid_Fails() {
         let sut = createRequestPerformer(
-            urlSession: createMockURLSession(data: invalidMockPersonJsonData)
+            urlSession: createMockURLSession(data: MockData.invalidMockPersonJsonData)
         )
         let exp = XCTestExpectation()
         sut.performTask(request: MockRequest()) { result in
@@ -253,7 +253,7 @@ private func createRequestPerformer(
 }
 
 private func createMockURLSession(
-    data: Data? = mockPersonJsonData,
+    data: Data? = MockData.mockPersonJsonData,
     statusCode: Int = 200,
     error: Error? = nil
 ) -> MockURLSession {

--- a/Tests/EZNetworkingTests/Validator/ResponseValidatorTests.swift
+++ b/Tests/EZNetworkingTests/Validator/ResponseValidatorTests.swift
@@ -28,7 +28,7 @@ final class URLResponseValidatorTests: XCTestCase {
     // MARK: - test validateData()
 
     func test_validateData_givenData_NoThrow() throws {
-        XCTAssertNoThrow(try sut.validateData(mockPersonJsonData))
+        XCTAssertNoThrow(try sut.validateData(MockData.mockPersonJsonData))
     }
     
     func test_validateData_givenNilData_Throws() throws {


### PR DESCRIPTION
1. Refactor mock data into a shared MockData object.
2. Unit tests for ImageDownloader were actually making API calls to decode the image url into Data. Refactored to avoid api calls. Greatly improved unit test speed.