### PR TITLE
File downloader improvements - add download progress tracking

### DIFF
--- a/Sources/EZNetworking/Interceptors/Protocols/DownloadTaskInterceptor.swift
+++ b/Sources/EZNetworking/Interceptors/Protocols/DownloadTaskInterceptor.swift
@@ -2,6 +2,9 @@ import Foundation
 
 /// Protocol for intercepting download tasks specifically.
 public protocol DownloadTaskInterceptor: AnyObject {
+    /// Track the progress of the download process
+    var progress: (Double) -> Void { get set }
+    
     /// Intercepts when a download task finishes downloading to a location.
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL)
 

--- a/Sources/EZNetworking/Util/Downloader/FileDownloadable.swift
+++ b/Sources/EZNetworking/Util/Downloader/FileDownloadable.swift
@@ -1,12 +1,14 @@
 import Foundation
 
+public typealias DownloadProgressHandler = (Double) -> Void
+
 public protocol FileDownloadable {
     func downloadFile(with url: URL) async throws -> URL
-    func downloadFile(with url: URL, progress: ((Double) -> Void)?) async throws -> URL
+    func downloadFile(with url: URL, progress: DownloadProgressHandler?) async throws -> URL
     @discardableResult
     func downloadFileTask(url: URL,completion: @escaping((Result<URL, NetworkingError>) -> Void)) -> URLSessionDownloadTask
     @discardableResult
-    func downloadFileTask(url: URL, progress: ((Double) -> Void)?, completion: @escaping((Result<URL, NetworkingError>) -> Void)) -> URLSessionDownloadTask
+    func downloadFileTask(url: URL, progress: DownloadProgressHandler?, completion: @escaping((Result<URL, NetworkingError>) -> Void)) -> URLSessionDownloadTask
 }
 
 public class FileDownloader: FileDownloadable {
@@ -60,7 +62,7 @@ public class FileDownloader: FileDownloadable {
         try await downloadFile(with: url, progress: nil)
     }
     
-    public func downloadFile(with url: URL, progress: ((Double) -> Void)? = nil) async throws -> URL {
+    public func downloadFile(with url: URL, progress: DownloadProgressHandler? = nil) async throws -> URL {
         do {
             configureProgressTracking(progress: progress)
 
@@ -82,7 +84,7 @@ public class FileDownloader: FileDownloadable {
         return downloadFileTask(url: url, progress: nil, completion: completion)
     }
     
-    public func downloadFileTask(url: URL, progress: ((Double) -> Void)?, completion: @escaping ((Result<URL, NetworkingError>) -> Void)) -> URLSessionDownloadTask {
+    public func downloadFileTask(url: URL, progress: DownloadProgressHandler?, completion: @escaping ((Result<URL, NetworkingError>) -> Void)) -> URLSessionDownloadTask {
         configureProgressTracking(progress: progress)
 
         let task = urlSession.downloadTask(with: url) { [weak self] localURL, response, error in

--- a/Sources/EZNetworking/Util/Downloader/FileDownloadable.swift
+++ b/Sources/EZNetworking/Util/Downloader/FileDownloadable.swift
@@ -64,7 +64,7 @@ public class FileDownloader: FileDownloadable {
         do {
             configureProgressTracking(progress: progress)
 
-            let (localURL, urlResponse) = try await urlSession.download(from: url, delegate: nil)
+            let (localURL, urlResponse) = try await urlSession.download(from: url, delegate: sessionDelegate)
             try validator.validateStatus(from: urlResponse)
             let unwrappedLocalURL = try validator.validateUrl(localURL)
             return unwrappedLocalURL

--- a/Sources/EZNetworking/Util/Downloader/FileDownloadable.swift
+++ b/Sources/EZNetworking/Util/Downloader/FileDownloadable.swift
@@ -98,6 +98,8 @@ public class FileDownloader: FileDownloadable {
                 completion(.success(localURL))
             } catch let networkError as NetworkingError {
                 completion(.failure(networkError))
+            } catch let error as URLError {
+                completion(.failure(.urlError(error)))
             } catch {
                 completion(.failure(.internalError(.unknown)))
             }

--- a/Sources/EZNetworking/Util/Downloader/FileDownloadable.swift
+++ b/Sources/EZNetworking/Util/Downloader/FileDownloadable.swift
@@ -111,15 +111,15 @@ public class FileDownloader: FileDownloadable {
     }
 
     private func configureProgressTracking(progress: ((Double) -> Void)?) {
-        if let progress = progress {
-            if sessionDelegate.downloadTaskInterceptor != nil {
-                // Update existing interceptor's progress handler
-                sessionDelegate.downloadTaskInterceptor?.progress = progress
-            } else {
-                // Set up fallback interceptor with progress handler
-                fallbackDownloadTaskInterceptor.progress = progress
-                sessionDelegate.downloadTaskInterceptor = fallbackDownloadTaskInterceptor
-            }
+        guard let progress else { return }
+
+        if sessionDelegate.downloadTaskInterceptor != nil {
+            // Update existing interceptor's progress handler
+            sessionDelegate.downloadTaskInterceptor?.progress = progress
+        } else {
+            // Set up fallback interceptor with progress handler
+            fallbackDownloadTaskInterceptor.progress = progress
+            sessionDelegate.downloadTaskInterceptor = fallbackDownloadTaskInterceptor
         }
     }
 }

--- a/Sources/EZNetworking/Util/Downloader/FileDownloadable.swift
+++ b/Sources/EZNetworking/Util/Downloader/FileDownloadable.swift
@@ -112,9 +112,11 @@ public class FileDownloader: FileDownloadable {
 
     private func configureProgressTracking(progress: ((Double) -> Void)?) {
         if let progress = progress {
-            if sessionDelegate.downloadTaskInterceptor != nil { // user is using custom DownloadTaskInterceptor
+            if sessionDelegate.downloadTaskInterceptor != nil {
+                // Update existing interceptor's progress handler
                 sessionDelegate.downloadTaskInterceptor?.progress = progress
             } else {
+                // Set up fallback interceptor with progress handler
                 fallbackDownloadTaskInterceptor.progress = progress
                 sessionDelegate.downloadTaskInterceptor = fallbackDownloadTaskInterceptor
             }

--- a/Sources/EZNetworking/Util/Downloader/FileDownloadable.swift
+++ b/Sources/EZNetworking/Util/Downloader/FileDownloadable.swift
@@ -86,11 +86,14 @@ public class FileDownloader: FileDownloadable {
         configureProgressTracking(progress: progress)
 
         let task = urlSession.downloadTask(with: url) { [weak self] localURL, response, error in
-            guard let self else { return }
+            guard let self else {
+                completion(.failure(.internalError(.lostReferenceOfSelf)))
+                return
+            }
             do {
-                try validator.validateNoError(error)
-                try validator.validateStatus(from: response)
-                let localURL = try validator.validateUrl(localURL)
+                try self.validator.validateNoError(error)
+                try self.validator.validateStatus(from: response)
+                let localURL = try self.validator.validateUrl(localURL)
                 
                 completion(.success(localURL))
             } catch let networkError as NetworkingError {

--- a/Sources/EZNetworking/Util/Downloader/FileDownloadable.swift
+++ b/Sources/EZNetworking/Util/Downloader/FileDownloadable.swift
@@ -6,7 +6,7 @@ public protocol FileDownloadable {
     func downloadFile(with url: URL) async throws -> URL
     func downloadFile(with url: URL, progress: DownloadProgressHandler?) async throws -> URL
     @discardableResult
-    func downloadFileTask(url: URL,completion: @escaping((Result<URL, NetworkingError>) -> Void)) -> URLSessionDownloadTask
+    func downloadFileTask(url: URL, completion: @escaping((Result<URL, NetworkingError>) -> Void)) -> URLSessionDownloadTask
     @discardableResult
     func downloadFileTask(url: URL, progress: DownloadProgressHandler?, completion: @escaping((Result<URL, NetworkingError>) -> Void)) -> URLSessionDownloadTask
 }

--- a/Sources/EZNetworking/Util/Downloader/FileDownloadable.swift
+++ b/Sources/EZNetworking/Util/Downloader/FileDownloadable.swift
@@ -2,26 +2,33 @@ import Foundation
 
 public protocol FileDownloadable {
     func downloadFile(with url: URL) async throws -> URL
+    func downloadFile(with url: URL, progress: ((Double) -> Void)?) async throws -> URL
     @discardableResult
-    func downloadFileTask(url: URL, completion: @escaping((Result<URL, NetworkingError>) -> Void)) -> URLSessionDownloadTask
+    func downloadFileTask(url: URL,completion: @escaping((Result<URL, NetworkingError>) -> Void)) -> URLSessionDownloadTask
+    @discardableResult
+    func downloadFileTask(url: URL, progress: ((Double) -> Void)?, completion: @escaping((Result<URL, NetworkingError>) -> Void)) -> URLSessionDownloadTask
 }
 
-public struct FileDownloader: FileDownloadable {
+public class FileDownloader: FileDownloadable {
     private let urlSession: URLSessionTaskProtocol
     private let validator: ResponseValidator
     private let requestDecoder: RequestDecodable
+    private var downloadTaskInterceptor: DownloadTaskInterceptor?
     
-    public init(sessionConfiguration: URLSessionConfiguration = .default,
-                sessionDelegate: SessionDelegate = SessionDelegate(),
-                delegateQueue: OperationQueue? = nil,
-                validator: ResponseValidator = ResponseValidatorImpl(),
-                requestDecoder: RequestDecodable = RequestDecoder()) {
+    public convenience init(
+        sessionConfiguration: URLSessionConfiguration = .default,
+        sessionDelegate: SessionDelegate = SessionDelegate(),
+        delegateQueue: OperationQueue? = nil,
+        validator: ResponseValidator = ResponseValidatorImpl(),
+        requestDecoder: RequestDecodable = RequestDecoder()
+    ) {
         let urlSession = URLSession(configuration: sessionConfiguration,
                                     delegate: sessionDelegate,
                                     delegateQueue: delegateQueue)
         self.init(urlSession: urlSession,
                   validator: validator,
                   requestDecoder: requestDecoder)
+        self.downloadTaskInterceptor = sessionDelegate.downloadTaskInterceptor
     }
 
     public init(urlSession: URLSessionTaskProtocol = URLSession.shared,
@@ -47,10 +54,36 @@ public struct FileDownloader: FileDownloadable {
             throw NetworkingError.internalError(.unknown)
         }
     }
+    
+    public func downloadFile(with url: URL, progress: ((Double) -> Void)? = nil) async throws -> URL {
+        do {
+            if let progress = progress {
+                if downloadTaskInterceptor != nil { // user is using custom DownloadTaskInterceptor
+                    downloadTaskInterceptor?.progress = progress
+                } else {
+                    downloadTaskInterceptor = DefaultDownloadTaskInterceptor(progress: progress)
+                }
+            }
+            let (localURL, urlResponse) = try await urlSession.download(from: url, delegate: nil)
+            
+            try validator.validateStatus(from: urlResponse)
+            let unwrappedLocalURL = try validator.validateUrl(localURL)
+            return unwrappedLocalURL
+        } catch let error as NetworkingError {
+            throw error
+        } catch let error as URLError {
+            throw NetworkingError.urlError(error)
+        } catch {
+            throw NetworkingError.internalError(.unknown)
+        }
+    }
+
+
 
     @discardableResult
     public func downloadFileTask(url: URL, completion: @escaping((Result<URL, NetworkingError>) -> Void)) -> URLSessionDownloadTask {
-        let task = urlSession.downloadTask(with: url) { localURL, response, error in
+        let task = urlSession.downloadTask(with: url) { [weak self] localURL, response, error in
+            guard let self else { return }
             do {
                 try validator.validateNoError(error)
                 try validator.validateStatus(from: response)
@@ -65,5 +98,54 @@ public struct FileDownloader: FileDownloadable {
         }
         task.resume()
         return task
+    }
+    
+    public func downloadFileTask(url: URL, progress: ((Double) -> Void)?, completion: @escaping ((Result<URL, NetworkingError>) -> Void)) -> URLSessionDownloadTask {
+        if let progress = progress {
+            if downloadTaskInterceptor != nil { // user is using custom DownloadTaskInterceptor
+                downloadTaskInterceptor?.progress = progress
+            } else {
+                downloadTaskInterceptor = DefaultDownloadTaskInterceptor(progress: progress)
+            }
+        }
+        let task = urlSession.downloadTask(with: url) { [weak self] localURL, response, error in
+            guard let self else { return }
+            do {
+                try validator.validateNoError(error)
+                try validator.validateStatus(from: response)
+                let localURL = try validator.validateUrl(localURL)
+                
+                completion(.success(localURL))
+            } catch let networkError as NetworkingError {
+                completion(.failure(networkError))
+            } catch {
+                completion(.failure(.internalError(.unknown)))
+            }
+        }
+        task.resume()
+        return task
+    }
+}
+
+/// Default implementation of DownloadTaskInterceptor
+private class DefaultDownloadTaskInterceptor: DownloadTaskInterceptor {
+    var progress: (Double) -> Void
+    
+    init(progress: @escaping (Double) -> Void = { _ in }) {
+        self.progress = progress
+    }
+    
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+        progress(1.0)
+    }
+    
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
+        let currentProgress = Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)
+        progress(currentProgress)
+    }
+    
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didResumeAtOffset fileOffset: Int64, expectedTotalBytes: Int64) {
+        let currentProgress = Double(fileOffset) / Double(expectedTotalBytes)
+        progress(currentProgress)
     }
 }

--- a/Tests/EZNetworkingTests/Interceptors/SessoionDelegate+Extensions+Tests/SessionDelegate+URLSessionDownloadDelegate+Tests.swift
+++ b/Tests/EZNetworkingTests/Interceptors/SessoionDelegate+Extensions+Tests/SessionDelegate+URLSessionDownloadDelegate+Tests.swift
@@ -38,6 +38,8 @@ final class SessionDelegateURLSessionDownloadDelegateTests: XCTestCase {
 // MARK: mock class
 
 private class MockDownloadTaskInterceptor: DownloadTaskInterceptor {
+    var progress: (Double) -> Void = { _ in }
+    
     var didFinishDownloading = false
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
         didFinishDownloading = true

--- a/Tests/EZNetworkingTests/Mocks/MockURLSession.swift
+++ b/Tests/EZNetworkingTests/Mocks/MockURLSession.swift
@@ -7,6 +7,7 @@ class MockURLSession: URLSessionTaskProtocol {
     var urlResponse: URLResponse?
     var error: Error?
     var completion: ((Data?, URLResponse?, Error?) -> Void)?
+    var sessionDelegate: SessionDelegate? = nil
     
     init(data: Data? = nil, urlResponse: URLResponse? = nil, error: Error? = nil) {
         self.data = data
@@ -68,6 +69,15 @@ class MockURLSession: URLSessionTaskProtocol {
     
     func downloadTask(with url: URL, completionHandler: @escaping @Sendable (URL?, URLResponse?, Error?) -> Void) -> URLSessionDownloadTask {
         
+        // track download progress - 33%
+        sessionDelegate?.downloadTaskInterceptor?.urlSession(.shared, downloadTask: .init(), didWriteData: 100, totalBytesWritten: 33, totalBytesExpectedToWrite: 100)
+        
+        // track resuming download progress - 66%
+        sessionDelegate?.downloadTaskInterceptor?.urlSession(.shared, downloadTask: .init(), didResumeAtOffset: 66, expectedTotalBytes: 100)
+        
+        // track download progress finished - 100%
+        sessionDelegate?.downloadTaskInterceptor?.urlSession(.shared, downloadTask: .init(), didFinishDownloadingTo: URL(fileURLWithPath: "/tmp/test.pdf"))
+
         return MockURLSessionDownloadTask {
             completionHandler(URL(fileURLWithPath: "/tmp/test.pdf"), self.urlResponse, self.error)
         }
@@ -80,6 +90,16 @@ class MockURLSession: URLSessionTaskProtocol {
         guard let urlResponse else {
             throw NetworkingError.internalError(.unknown)
         }
+        
+        // track download progress - 33%
+        sessionDelegate?.downloadTaskInterceptor?.urlSession(.shared, downloadTask: .init(), didWriteData: 100, totalBytesWritten: 33, totalBytesExpectedToWrite: 100)
+        
+        // track resuming download progress - 66%
+        sessionDelegate?.downloadTaskInterceptor?.urlSession(.shared, downloadTask: .init(), didResumeAtOffset: 66, expectedTotalBytes: 100)
+        
+        // track download progress finished - 100%
+        sessionDelegate?.downloadTaskInterceptor?.urlSession(.shared, downloadTask: .init(), didFinishDownloadingTo: URL(fileURLWithPath: "/tmp/test.pdf"))
+
         return (URL(fileURLWithPath: "/tmp/test.pdf"), urlResponse)
     }
 }

--- a/Tests/EZNetworkingTests/Mocks/MockURLSession.swift
+++ b/Tests/EZNetworkingTests/Mocks/MockURLSession.swift
@@ -69,14 +69,7 @@ class MockURLSession: URLSessionTaskProtocol {
     
     func downloadTask(with url: URL, completionHandler: @escaping @Sendable (URL?, URLResponse?, Error?) -> Void) -> URLSessionDownloadTask {
         
-        // track download progress - 33%
-        sessionDelegate?.downloadTaskInterceptor?.urlSession(.shared, downloadTask: .init(), didWriteData: 100, totalBytesWritten: 33, totalBytesExpectedToWrite: 100)
-        
-        // track resuming download progress - 66%
-        sessionDelegate?.downloadTaskInterceptor?.urlSession(.shared, downloadTask: .init(), didResumeAtOffset: 66, expectedTotalBytes: 100)
-        
-        // track download progress finished - 100%
-        sessionDelegate?.downloadTaskInterceptor?.urlSession(.shared, downloadTask: .init(), didFinishDownloadingTo: URL(fileURLWithPath: "/tmp/test.pdf"))
+        simulateDownloadProgress(for: .init())
 
         return MockURLSessionDownloadTask {
             completionHandler(URL(fileURLWithPath: "/tmp/test.pdf"), self.urlResponse, self.error)
@@ -91,16 +84,37 @@ class MockURLSession: URLSessionTaskProtocol {
             throw NetworkingError.internalError(.unknown)
         }
         
-        // track download progress - 33%
-        sessionDelegate?.downloadTaskInterceptor?.urlSession(.shared, downloadTask: .init(), didWriteData: 100, totalBytesWritten: 33, totalBytesExpectedToWrite: 100)
-        
-        // track resuming download progress - 66%
-        sessionDelegate?.downloadTaskInterceptor?.urlSession(.shared, downloadTask: .init(), didResumeAtOffset: 66, expectedTotalBytes: 100)
-        
-        // track download progress finished - 100%
-        sessionDelegate?.downloadTaskInterceptor?.urlSession(.shared, downloadTask: .init(), didFinishDownloadingTo: URL(fileURLWithPath: "/tmp/test.pdf"))
+        simulateDownloadProgress(for: .init())
 
         return (URL(fileURLWithPath: "/tmp/test.pdf"), urlResponse)
+    }
+}
+
+extension MockURLSession {
+    private func simulateDownloadProgress(for task: URLSessionDownloadTask) {
+        // Simulate 50% progress
+        sessionDelegate?.urlSession(
+            .shared,
+            downloadTask: task,
+            didWriteData: 50,
+            totalBytesWritten: 50,
+            totalBytesExpectedToWrite: 100
+        )
+        
+        // Simulate completion
+        sessionDelegate?.urlSession(
+            .shared,
+            downloadTask: task,
+            didWriteData: 50,
+            totalBytesWritten: 100,
+            totalBytesExpectedToWrite: 100
+        )
+        
+        sessionDelegate?.urlSession(
+            .shared,
+            downloadTask: task,
+            didFinishDownloadingTo: URL(fileURLWithPath: "/tmp/test.pdf")
+        )
     }
 }
 


### PR DESCRIPTION
## What's new?

In this PR, I am expanding on the FileDownloadable to include download progress tracking. With recent change with `SessionDelegate` this was already possible nut now it's even easier.

### How to track file download - before

```swift
struct CustomDownloadTaskInterceptor: DownloadTaskInterceptor {
    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
        // track progress
    }

    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
        // track progress
    }

    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didResumeAtOffset fileOffset: Int64, expectedTotalBytes: Int64) {
        // track progress
    }
}

let sessionDelegate = SessionDelegate()
sessionDelegate.downloadTaskInterceptor = CustomDownloadTaskInterceptor()

let downloader = FileDownloader(sessionDelegate: sessionDelegate)
let downloadTask = downloader.downloadFileTask(url: _) { result in
    // handle result
}

do {
    let url = try downloader.downloadFile(url: _)
    // handle result
} catch {
    // error handling
}
```

### How to track file download - after

The above code still works but now we can track the progress from a closure

```swift
let sessionDelegate = SessionDelegate()

// if you want to use your own custom DownloadTaskInterceptor, you can still pass, 
// but if you do not, tracking still works with an internal default interceptor
sessionDelegate.downloadTaskInterceptor = CustomDownloadTaskInterceptor()

let downloader = FileDownloader(sessionDelegate: sessionDelegate)
let downloadTask = downloader.downloadFileTask(url: _, progress: { progress in
    // handle tracking progress
}) { result in
    // handle result
}

do {
    let url = try downloader.downloadFile(url: _, progress: { progress in
        // handle tracking progress
    })
    // handle result
} catch {
    // error handling
}
```