### PR TITLE
WebSocket - p1 - update WebSocketTaskInterceptor

### DIFF
--- a/Sources/EZNetworking/Interceptors/Protocols/WebSocketTaskInterceptor.swift
+++ b/Sources/EZNetworking/Interceptors/Protocols/WebSocketTaskInterceptor.swift
@@ -2,9 +2,20 @@ import Foundation
 
 /// Protocol for intercepting WebSocket tasks specifically.
 public protocol WebSocketTaskInterceptor: AnyObject {
+    var onEvent: ((WebSocketTaskEvent) -> Void)? { get set }
+
     /// Intercepts when a WebSocket task opens with a protocol.
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?)
 
     /// Intercepts when a WebSocket task closes with a code and reason.
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?)
+    
+    /// Intercepts when a task completes with  an error.
+       func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error)
+}
+
+public enum WebSocketTaskEvent {
+    case didOpenWithProtocol(protocolStr: String?)
+    case didOpenWithError(error: Error)
+    case didClose(code: URLSessionWebSocketTask.CloseCode, reason: Data?)
 }

--- a/Sources/EZNetworking/Interceptors/SessionDelegate+Extensions/SessionDelegate+URLSessionTaskDelegate.swift
+++ b/Sources/EZNetworking/Interceptors/SessionDelegate+Extensions/SessionDelegate+URLSessionTaskDelegate.swift
@@ -28,6 +28,10 @@ extension SessionDelegate: URLSessionTaskDelegate {
                           task: URLSessionTask,
                           didCompleteWithError error: Error?) {
         taskLifecycleInterceptor?.urlSession(session, task: task, didCompleteWithError: error)
+        
+        if let error = error {
+            webSocketTaskInterceptor?.urlSession(session, task: task, didCompleteWithError: error)
+        }
     }
 
     public func urlSession(_ session: URLSession,

--- a/Tests/EZNetworkingTests/Interceptors/SessoionDelegate+Extensions+Tests/SessionDelegate+URLSessionWebSocketDelegate+Tests.swift
+++ b/Tests/EZNetworkingTests/Interceptors/SessoionDelegate+Extensions+Tests/SessionDelegate+URLSessionWebSocketDelegate+Tests.swift
@@ -33,22 +33,44 @@ final class SessionDelegateURLSessionWebSocketDelegateTests {
         #expect(webSocketInterceptor.receivedCloseCode == closeCode)
         #expect(webSocketInterceptor.receivedReason == reasonData)
     }
+    
+    @Test("test SessionDelegate WebSocket didCompleteWithError")
+    func testSessionDelegateWebSocketDidCompleteWithError() {
+        let webSocketInterceptor = MockWebSocketTaskInterceptor()
+        let delegate = SessionDelegate()
+        delegate.webSocketTaskInterceptor = webSocketInterceptor
+        
+        
+        let error = NSError(domain: "test", code: 0)
+        delegate.urlSession(.shared, task: .init(), didCompleteWithError: error)
+        
+        #expect(webSocketInterceptor.didCompleteWithError)
+        #expect(webSocketInterceptor.receivedError as? NSError == error)
+    }
 }
 
 // MARK: mock class
 
 private class MockWebSocketTaskInterceptor: WebSocketTaskInterceptor {
-    var didOpenWithProtocol = false
-    var didCloseWithCodeAndReason = false
-    var receivedProtocol: String?
-    var receivedCloseCode: URLSessionWebSocketTask.CloseCode?
-    var receivedReason: Data?
+    var onEvent: ((WebSocketTaskEvent) -> Void)? = { _ in }
     
+    var didOpenWithProtocol = false
+    var receivedProtocol: String?
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
         didOpenWithProtocol = true
         receivedProtocol = `protocol`
     }
     
+    var didCompleteWithError = false
+    var receivedError: Error?
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: any Error) {
+        didCompleteWithError = true
+        receivedError = error
+    }
+    
+    var didCloseWithCodeAndReason = false
+    var receivedCloseCode: URLSessionWebSocketTask.CloseCode?
+    var receivedReason: Data?
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
         didCloseWithCodeAndReason = true
         receivedCloseCode = closeCode
@@ -61,4 +83,3 @@ private class MockWebSocketTaskInterceptor: WebSocketTaskInterceptor {
 private var mockURLSessionWebSocketTask: URLSessionWebSocketTask {
     URLSession.shared.webSocketTask(with: URL(string: "wss://www.example.com")!)
 }
-


### PR DESCRIPTION
This will be the first of several PRs to add WebSocket support. The original plan was to do it in a single PR but it began to grow large so decided to break it up into several smaller PRs.

## What's new?

In this PR, I am updating the `WebSocketTaskInterceptor` to also track when the web socket connection was established with an error.

Also added `WebSocketTaskEvent` and `onEvent` closure