### PR TITLE
WebSocket - p5 - added WebSocketConnectionState

### DIFF
--- a/Sources/EZNetworking/Util/WebSocket/Helpers/WebSocketConnectionState.swift
+++ b/Sources/EZNetworking/Util/WebSocket/Helpers/WebSocketConnectionState.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public enum WebSocketConnectionState: Equatable {
+    case idle
+    case disconnected
+    case connecting
+    case connected(protocol: String?)
+    case connectionLost(reason: WebSocketError)
+    case failed(error: WebSocketError)
+
+    public static func == (lhs: WebSocketConnectionState, rhs: WebSocketConnectionState) -> Bool {
+        switch (lhs, rhs) {
+        case (.idle, .idle):
+            return true
+        case (.disconnected, .disconnected):
+            return true
+        case (.connecting, .connecting):
+            return true
+        case (.connected(let lhsProto), .connected(let rhsProto)):
+            return lhsProto == rhsProto
+        case (.connectionLost(let lhsError), .connectionLost(let rhsError)):
+            return lhsError == rhsError
+        case (.failed(let lhsError), .failed(let rhsError)):
+            return lhsError == rhsError
+        default:
+            return false
+        }
+    }
+}

--- a/Tests/EZNetworkingTests/Util/WebSocket/Helpers/WebSocketConnectionStateTests.swift
+++ b/Tests/EZNetworkingTests/Util/WebSocket/Helpers/WebSocketConnectionStateTests.swift
@@ -1,0 +1,42 @@
+@testable import EZNetworking
+import Foundation
+import Testing
+
+@Suite("Test WebSocketConnectionState")
+final class WebSocketConnectionStateTests {
+    @Test("basic equality for simple states")
+    func testBasicEquality() {
+        #expect(WebSocketConnectionState.disconnected == .disconnected)
+        #expect(WebSocketConnectionState.connecting == .connecting)
+        #expect(WebSocketConnectionState.idle == .idle)
+    }
+
+    @Test("connected state equality with protocol values")
+    func testConnectedEquality() {
+        #expect(WebSocketConnectionState.connected(protocol: nil) == .connected(protocol: nil))
+        #expect(WebSocketConnectionState.connected(protocol: "chat") == .connected(protocol: "chat"))
+        #expect(WebSocketConnectionState.connected(protocol: "chat") != .connected(protocol: "video"))
+        #expect(WebSocketConnectionState.connected(protocol: nil) != .connected(protocol: "chat"))
+    }
+
+    @Test("connectionLost and failed equality by underlying WebSocketError")
+    func testErrorAssociatedEquality() {
+        let err1 = WebSocketError.connectionFailed(underlying: URLError(.notConnectedToInternet))
+        let err2 = WebSocketError.connectionFailed(underlying: URLError(.notConnectedToInternet))
+        let other = WebSocketError.connectionFailed(underlying: NSError(domain: "x", code: 1))
+
+        #expect(WebSocketConnectionState.connectionLost(reason: err1) == .connectionLost(reason: err2))
+        #expect(WebSocketConnectionState.connectionLost(reason: err1) != .connectionLost(reason: other))
+
+        #expect(WebSocketConnectionState.failed(error: err1) == .failed(error: err2))
+        #expect(WebSocketConnectionState.failed(error: err1) != .failed(error: other))
+    }
+
+    @Test("different enum cases are not equal")
+    func testDifferentCasesNotEqual() {
+        #expect(WebSocketConnectionState.disconnected != .connecting)
+        #expect(WebSocketConnectionState.disconnected != .connected(protocol: nil))
+        #expect(WebSocketConnectionState.connecting != .connected(protocol: "p"))
+        #expect(WebSocketConnectionState.connectionLost(reason: WebSocketError.taskCancelled) != .failed(error: WebSocketError.taskCancelled))
+    }
+}


### PR DESCRIPTION
This PR is one of several to add WebSocket support. Here are links to past PRs:

1. https://github.com/Aldo10012/EZNetworking/pull/55
2. https://github.com/Aldo10012/EZNetworking/pull/59
3. https://github.com/Aldo10012/EZNetworking/pull/58
4. https://github.com/Aldo10012/EZNetworking/pull/57

## What's new?

In this PR, I added `WebSocketConnectionState`, an enum describing the connection state for the web socket.