### PR TITLE
Gha multiple swift versions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift-version: ['6.0', '6.1', '6.2']
+        swift-version: ['5.10', '6.0', '6.1', '6.2']
     
     steps:
       - name: Checkout code
@@ -38,10 +38,11 @@ jobs:
         run: swift build
       
       - name: Run Tests
+        if: matrix.swift-version != '5.10'
         run: swift test --enable-code-coverage
       
       # - name: Generate Code Coverage Report
-      #   if: success()
+      #   if: success() && matrix.swift-version != '5.10'
       #   run: |
       #     xcrun llvm-cov export \
       #       -instr-profile .build/debug/codecov/default.profdata \
@@ -49,7 +50,7 @@ jobs:
       #       -format="lcov" > coverage.lcov
       
       # - name: Upload Coverage Report
-      #   if: success()
+      #   if: success() && matrix.swift-version != '5.10'
       #   uses: actions/upload-artifact@v4
       #   with:
       #     name: coverage-report-ios-${{ matrix.swift-version }}
@@ -57,7 +58,7 @@ jobs:
       #     retention-days: 30
       
       # - name: Display Coverage Summary
-      #   if: success()
+      #   if: success() && matrix.swift-version != '5.10'
       #   run: |
       #     xcrun llvm-cov report \
       #       -instr-profile .build/debug/codecov/default.profdata \


### PR DESCRIPTION
## What's new?

This PR adds a patrix to the Github Actions build-and-test workflow. Now we ensure that EZNetworking compiles in Swift 6.0, Swift 6.1, and swift 6.2.

Why was Swift 5.10 not included in the test step?

Swift 5.10 does NOT support **Swift Testing**, and all unit tests rely on Swift Testing. If the CI attempted to run tests on Swift 5.10, the job will fail.