### PR TITLE
added code coverage steps

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           SWIFT_PATH=$(which swift)
           TOOLCHAIN_PATH=$(dirname $(dirname $SWIFT_PATH))
-          $TOOLCHAIN_PATH/usr/bin/llvm-cov report \
+          $TOOLCHAIN_PATH/bin/llvm-cov report \
             -instr-profile .build/arm64-apple-macosx/debug/codecov/default.profdata \
             .build/arm64-apple-macosx/debug/${{ steps.package-name.outputs.name }}PackageTests.xctest/Contents/MacOS/${{ steps.package-name.outputs.name }}PackageTests
       
@@ -99,7 +99,7 @@ jobs:
         run: |
           SWIFT_PATH=$(which swift)
           TOOLCHAIN_PATH=$(dirname $(dirname $SWIFT_PATH))
-          $TOOLCHAIN_PATH/usr/bin/llvm-cov export \
+          $TOOLCHAIN_PATH/bin/llvm-cov export \
             -instr-profile .build/arm64-apple-macosx/debug/codecov/default.profdata \
             .build/arm64-apple-macosx/debug/${{ steps.package-name.outputs.name }}PackageTests.xctest/Contents/MacOS/${{ steps.package-name.outputs.name }}PackageTests \
             -format="lcov" > coverage.lcov


### PR DESCRIPTION
## What's new?

Added Code Coverage step to the test job. 

#### Note:
Code coverage is reported in the CI log, not on a PR comment.