### PR TITLE
simplify code coverage steps

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -75,46 +75,19 @@ jobs:
         run: swift test --enable-code-coverage
       
       # --- Coverage Reporting (Non-blocking) ---
-      
-      - name: Get Package Name
-        id: package-name
+
+      - name: Generate Coverage Report (LCOV)
         continue-on-error: true
         run: |
           PACKAGE_NAME=$(swift package describe --type json | jq -r '.name')
-          echo "name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
-      
-      - name: Display Coverage Summary
-        if: steps.package-name.outcome == 'success'
-        continue-on-error: true
-        run: |
-          SWIFT_PATH=$(which swift)
-          TOOLCHAIN_PATH=$(dirname $(dirname $SWIFT_PATH))
-          $TOOLCHAIN_PATH/bin/llvm-cov report \
-            -instr-profile .build/arm64-apple-macosx/debug/codecov/default.profdata \
-            .build/arm64-apple-macosx/debug/${{ steps.package-name.outputs.name }}PackageTests.xctest/Contents/MacOS/${{ steps.package-name.outputs.name }}PackageTests
-      
-      - name: Generate Coverage Report (LCOV)
-        if: steps.package-name.outcome == 'success'
-        continue-on-error: true
-        run: |
           SWIFT_PATH=$(which swift)
           TOOLCHAIN_PATH=$(dirname $(dirname $SWIFT_PATH))
           $TOOLCHAIN_PATH/bin/llvm-cov export \
             -instr-profile .build/arm64-apple-macosx/debug/codecov/default.profdata \
-            .build/arm64-apple-macosx/debug/${{ steps.package-name.outputs.name }}PackageTests.xctest/Contents/MacOS/${{ steps.package-name.outputs.name }}PackageTests \
+            .build/arm64-apple-macosx/debug/${PACKAGE_NAME}PackageTests.xctest/Contents/MacOS/${PACKAGE_NAME}PackageTests \
             -format="lcov" > coverage.lcov
       
-      - name: Upload Coverage Artifact
-        if: steps.package-name.outcome == 'success'
-        continue-on-error: true
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-report-swift-6.2
-          path: coverage.lcov
-          retention-days: 30
-      
       - name: Upload to Codecov
-        if: steps.package-name.outcome == 'success'
         continue-on-error: true
         uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
## What's new?

Simplify code coverage steps in the test job. Codecov integration made some of the steps redundant. 