### PR TITLE
add build step for macOS Swift 6.3

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       platform: macOS
-      swift-versions: '["5.10", "6.0", "6.1", "6.2"]'
+      swift-versions: '["5.10", "6.0", "6.1", "6.2", "6.3"]'
 
   build-iOS:
     name: Build iOS


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline to test against an additional Swift toolchain version for enhanced compatibility verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->