### PR TITLE
make interceptor events sendable

### DIFF
--- a/Sources/EZNetworking/Core/Session/Interceptors/DefaultInterceptors/DefaultDownloadTaskInterceptor.swift
+++ b/Sources/EZNetworking/Core/Session/Interceptors/DefaultInterceptors/DefaultDownloadTaskInterceptor.swift
@@ -2,12 +2,12 @@ import Foundation
 
 /// Default implementation of DownloadTaskInterceptor
 class DefaultDownloadTaskInterceptor: DownloadTaskInterceptor {
-    var onEvent: (DownloadTaskInterceptorEvent) -> Void
+    var onEvent: @Sendable (DownloadTaskInterceptorEvent) -> Void
     private let validator: ResponseValidator
 
     init(
         validator: ResponseValidator = DefaultResponseValidator(),
-        onEvent: @escaping (DownloadTaskInterceptorEvent) -> Void = { _ in }
+        onEvent: @Sendable @escaping (DownloadTaskInterceptorEvent) -> Void = { _ in }
     ) {
         self.validator = validator
         self.onEvent = onEvent
@@ -18,7 +18,7 @@ class DefaultDownloadTaskInterceptor: DownloadTaskInterceptor {
             try validator.validateStatus(from: downloadTask.response)
             onEvent(.onDownloadCompleted(location))
         } catch {
-            onEvent(.onDownloadFailed(error, resumeData: nil))
+            onEvent(.onDownloadFailed(error.asSendableError, resumeData: nil))
         }
     }
 
@@ -36,6 +36,6 @@ class DefaultDownloadTaskInterceptor: DownloadTaskInterceptor {
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error) {
         let resumeData = (error as? URLError)?.downloadTaskResumeData
-        onEvent(.onDownloadFailed(error, resumeData: resumeData))
+        onEvent(.onDownloadFailed(error.asSendableError, resumeData: resumeData))
     }
 }

--- a/Sources/EZNetworking/Core/Session/Interceptors/DefaultInterceptors/DefaultUploadTaskInterceptor.swift
+++ b/Sources/EZNetworking/Core/Session/Interceptors/DefaultInterceptors/DefaultUploadTaskInterceptor.swift
@@ -2,13 +2,13 @@ import Foundation
 
 /// Default implementation of UploadTaskInterceptor
 class DefaultUploadTaskInterceptor: UploadTaskInterceptor {
-    var onEvent: (UploadTaskInterceptorEvent) -> Void
+    var onEvent: @Sendable (UploadTaskInterceptorEvent) -> Void
     private let validator: ResponseValidator
     private var receivedData = Data()
 
     init(
         validator: ResponseValidator = DefaultResponseValidator(),
-        onEvent: @escaping (UploadTaskInterceptorEvent) -> Void = { _ in }
+        onEvent: @Sendable @escaping (UploadTaskInterceptorEvent) -> Void = { _ in }
     ) {
         self.validator = validator
         self.onEvent = onEvent
@@ -30,14 +30,14 @@ class DefaultUploadTaskInterceptor: UploadTaskInterceptor {
             // URLSession does not surface a public resume-data key in URLError.userInfo for upload tasks
             // the way it does for downloads (`NSURLSessionDownloadTaskResumeData`). Spontaneous-failure
             // resume support for uploads only exists via explicit `cancelByProducingResumeData()`.
-            onEvent(.onUploadFailed(error, resumeData: nil))
+            onEvent(.onUploadFailed(error.asSendableError, resumeData: nil))
             return
         }
         do {
             try validator.validateStatus(from: task.response)
             onEvent(.onUploadCompleted(receivedData))
         } catch {
-            onEvent(.onUploadFailed(error, resumeData: nil))
+            onEvent(.onUploadFailed(error.asSendableError, resumeData: nil))
         }
     }
 }

--- a/Sources/EZNetworking/Core/Session/Interceptors/DefaultInterceptors/DefaultWebSocketTaskInterceptor.swift
+++ b/Sources/EZNetworking/Core/Session/Interceptors/DefaultInterceptors/DefaultWebSocketTaskInterceptor.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 class DefaultWebSocketTaskInterceptor: WebSocketTaskInterceptor {
-    var onEvent: ((WebSocketTaskEvent) -> Void)?
+    var onEvent: (@Sendable (WebSocketTaskEvent) -> Void)?
 
-    init(onEvent: ((WebSocketTaskEvent) -> Void)? = nil) {
+    init(onEvent: (@Sendable (WebSocketTaskEvent) -> Void)? = nil) {
         self.onEvent = onEvent
     }
 
@@ -12,7 +12,7 @@ class DefaultWebSocketTaskInterceptor: WebSocketTaskInterceptor {
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: any Error) {
-        onEvent?(.didOpenWithError(error: error))
+        onEvent?(.didOpenWithError(error: error.asSendableError))
     }
 
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {

--- a/Sources/EZNetworking/Core/Session/Interceptors/Protocols/DownloadTaskInterceptor.swift
+++ b/Sources/EZNetworking/Core/Session/Interceptors/Protocols/DownloadTaskInterceptor.swift
@@ -1,15 +1,15 @@
 import Foundation
 
-public enum DownloadTaskInterceptorEvent {
+public enum DownloadTaskInterceptorEvent: Sendable {
     case onProgress(Double)
     case onDownloadCompleted(URL)
-    case onDownloadFailed(Error, resumeData: Data?)
+    case onDownloadFailed(SendableError, resumeData: Data?)
 }
 
 /// Protocol for intercepting download tasks specifically.
 public protocol DownloadTaskInterceptor: AnyObject {
     /// Callback for download task events (progress, completion, failure)
-    var onEvent: (DownloadTaskInterceptorEvent) -> Void { get set }
+    var onEvent: @Sendable (DownloadTaskInterceptorEvent) -> Void { get set }
 
     /// Intercepts when a download task finishes downloading to a location.
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL)

--- a/Sources/EZNetworking/Core/Session/Interceptors/Protocols/UploadTaskInterceptor.swift
+++ b/Sources/EZNetworking/Core/Session/Interceptors/Protocols/UploadTaskInterceptor.swift
@@ -1,15 +1,15 @@
 import Foundation
 
-public enum UploadTaskInterceptorEvent {
+public enum UploadTaskInterceptorEvent: Sendable {
     case onProgress(Double)
     case onUploadCompleted(Data)
-    case onUploadFailed(Error, resumeData: Data?)
+    case onUploadFailed(SendableError, resumeData: Data?)
 }
 
 /// Protocol for intercepting upload tasks specifically.
 public protocol UploadTaskInterceptor: AnyObject {
     /// Callback for upload task events (progress, completion, failure)
-    var onEvent: (UploadTaskInterceptorEvent) -> Void { get set }
+    var onEvent: @Sendable (UploadTaskInterceptorEvent) -> Void { get set }
 
     /// Intercepts progress updates as the request body is sent.
     func urlSession(_ session: URLSession, task: URLSessionTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64)

--- a/Sources/EZNetworking/Core/Session/Interceptors/Protocols/WebSocketTaskInterceptor.swift
+++ b/Sources/EZNetworking/Core/Session/Interceptors/Protocols/WebSocketTaskInterceptor.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Protocol for intercepting WebSocket tasks specifically.
 public protocol WebSocketTaskInterceptor: AnyObject {
-    var onEvent: ((WebSocketTaskEvent) -> Void)? { get set }
+    var onEvent: (@Sendable (WebSocketTaskEvent) -> Void)? { get set }
 
     /// Intercepts when a WebSocket task opens with a protocol.
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?)
@@ -14,8 +14,8 @@ public protocol WebSocketTaskInterceptor: AnyObject {
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error)
 }
 
-public enum WebSocketTaskEvent {
+public enum WebSocketTaskEvent: Sendable {
     case didOpenWithProtocol(protocolStr: String?)
-    case didOpenWithError(error: Error)
+    case didOpenWithError(error: SendableError)
     case didClose(code: URLSessionWebSocketTask.CloseCode, reason: Data?)
 }

--- a/Tests/EZNetworkingTests/Core/Session/SessionDelegate+Extensions+Tests/SessionDelegate+URLSessionDataDelegate+Tests.swift
+++ b/Tests/EZNetworkingTests/Core/Session/SessionDelegate+Extensions+Tests/SessionDelegate+URLSessionDataDelegate+Tests.swift
@@ -110,7 +110,7 @@ final class SessionDelegateURLSessionDataDelegateTest {
 // MARK: spy upload interceptor
 
 private class SpyUploadTaskInterceptor: UploadTaskInterceptor {
-    var onEvent: (UploadTaskInterceptorEvent) -> Void = { _ in }
+    var onEvent: @Sendable (UploadTaskInterceptorEvent) -> Void = { _ in }
 
     var didReceiveData = false
 

--- a/Tests/EZNetworkingTests/Core/Session/SessionDelegate+Extensions+Tests/SessionDelegate+URLSessionDownloadDelegate+Tests.swift
+++ b/Tests/EZNetworkingTests/Core/Session/SessionDelegate+Extensions+Tests/SessionDelegate+URLSessionDownloadDelegate+Tests.swift
@@ -53,7 +53,7 @@ final class SessionDelegateURLSessionDownloadDelegateTests {
 // MARK: mock class
 
 private class DownloadTaskInterceptorMock: DownloadTaskInterceptor {
-    var onEvent: (DownloadTaskInterceptorEvent) -> Void = { _ in }
+    var onEvent: @Sendable (DownloadTaskInterceptorEvent) -> Void = { _ in }
 
     var didFinishDownloading = false
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {

--- a/Tests/EZNetworkingTests/Core/Session/SessionDelegate+Extensions+Tests/SessionDelegate+URLSessionTaskDelegate+Tests.swift
+++ b/Tests/EZNetworkingTests/Core/Session/SessionDelegate+Extensions+Tests/SessionDelegate+URLSessionTaskDelegate+Tests.swift
@@ -236,7 +236,7 @@ private var mockURLSessionTaskMetrics: URLSessionTaskMetrics {
 }
 
 private class SpyDownloadTaskInterceptor: DownloadTaskInterceptor {
-    var onEvent: (DownloadTaskInterceptorEvent) -> Void = { _ in }
+    var onEvent: @Sendable (DownloadTaskInterceptorEvent) -> Void = { _ in }
     var didCompleteWithError = false
 
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {}
@@ -248,7 +248,7 @@ private class SpyDownloadTaskInterceptor: DownloadTaskInterceptor {
 }
 
 private class SpyWebSocketTaskInterceptor: WebSocketTaskInterceptor {
-    var onEvent: ((WebSocketTaskEvent) -> Void)? = { _ in }
+    var onEvent: (@Sendable (WebSocketTaskEvent) -> Void)? = { _ in }
     var didCompleteWithError = false
 
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {}
@@ -259,7 +259,7 @@ private class SpyWebSocketTaskInterceptor: WebSocketTaskInterceptor {
 }
 
 private class SpyUploadTaskInterceptor: UploadTaskInterceptor {
-    var onEvent: (UploadTaskInterceptorEvent) -> Void = { _ in }
+    var onEvent: @Sendable (UploadTaskInterceptorEvent) -> Void = { _ in }
 
     var didSendBodyData = false
     var didReceiveData = false

--- a/Tests/EZNetworkingTests/Core/Session/SessionDelegate+Extensions+Tests/SessionDelegate+URLSessionWebSocketDelegate+Tests.swift
+++ b/Tests/EZNetworkingTests/Core/Session/SessionDelegate+Extensions+Tests/SessionDelegate+URLSessionWebSocketDelegate+Tests.swift
@@ -50,7 +50,7 @@ final class SessionDelegateURLSessionWebSocketDelegateTests {
 // MARK: mock class
 
 private class SpyWebSocketTaskInterceptor: WebSocketTaskInterceptor {
-    var onEvent: ((WebSocketTaskEvent) -> Void)? = { _ in }
+    var onEvent: (@Sendable (WebSocketTaskEvent) -> Void)? = { _ in }
 
     var didOpenWithProtocol = false
     var receivedProtocol: String?

--- a/Tests/EZNetworkingTests/Services/Downloader/Mocks/MockDownloadTaskInterceptor.swift
+++ b/Tests/EZNetworkingTests/Services/Downloader/Mocks/MockDownloadTaskInterceptor.swift
@@ -2,7 +2,7 @@ import EZNetworking
 import Foundation
 
 class MockDownloadTaskInterceptor: DownloadTaskInterceptor {
-    var onEvent: (DownloadTaskInterceptorEvent) -> Void = { _ in }
+    var onEvent: @Sendable (DownloadTaskInterceptorEvent) -> Void = { _ in }
     init() {}
 
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {}
@@ -19,6 +19,6 @@ class MockDownloadTaskInterceptor: DownloadTaskInterceptor {
     }
 
     func simulateFailure(_ error: Error, resumeData: Data? = nil) {
-        onEvent(.onDownloadFailed(error, resumeData: resumeData))
+        onEvent(.onDownloadFailed(error.asSendableError, resumeData: resumeData))
     }
 }

--- a/Tests/EZNetworkingTests/Services/Uploader/FileUploader/Mocks/MockUploadTaskInterceptor.swift
+++ b/Tests/EZNetworkingTests/Services/Uploader/FileUploader/Mocks/MockUploadTaskInterceptor.swift
@@ -2,7 +2,7 @@ import EZNetworking
 import Foundation
 
 class MockUploadTaskInterceptor: UploadTaskInterceptor {
-    var onEvent: (UploadTaskInterceptorEvent) -> Void = { _ in }
+    var onEvent: @Sendable (UploadTaskInterceptorEvent) -> Void = { _ in }
     init() {}
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64) {}
@@ -18,6 +18,6 @@ class MockUploadTaskInterceptor: UploadTaskInterceptor {
     }
 
     func simulateFailure(_ error: Error, resumeData: Data? = nil) {
-        onEvent(.onUploadFailed(error, resumeData: resumeData))
+        onEvent(.onUploadFailed(error.asSendableError, resumeData: resumeData))
     }
 }

--- a/Tests/EZNetworkingTests/Services/WebSocket/Mocks/MockWebSocketTaskInterceptor.swift
+++ b/Tests/EZNetworkingTests/Services/WebSocket/Mocks/MockWebSocketTaskInterceptor.swift
@@ -8,14 +8,14 @@ class MockWebSocketTaskInterceptor: WebSocketTaskInterceptor {
     private let session = URLSession.shared
     private lazy var task: URLSessionWebSocketTask = session.webSocketTask(with: webSocketUrl, protocols: [])
 
-    var onEvent: ((WebSocketTaskEvent) -> Void)?
+    var onEvent: (@Sendable (WebSocketTaskEvent) -> Void)?
 
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
         onEvent?(.didOpenWithProtocol(protocolStr: `protocol`))
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: any Error) {
-        onEvent?(.didOpenWithError(error: error))
+        onEvent?(.didOpenWithError(error: error.asSendableError))
     }
 
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {


### PR DESCRIPTION
## What's new?

This PR addresses this issue: https://github.com/Aldo10012/EZNetworking/issues/137

Make interceptor events conform to the `Sendable` protocol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal concurrency safety across networking interceptors to improve thread-safe error handling and callback mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Aldo10012/EZNetworking/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->