### PR TITLE
clean up IntervalDuration

### DIFF
--- a/Documentation/05_liveConnumication.md
+++ b/Documentation/05_liveConnumication.md
@@ -235,7 +235,7 @@ let ws = WebSocket(request: request)
 
 Both init methods of `WebSocket` also takes a `PingConfig`, which is used to control ping-pong logic.
 It takes the following as init arguments:
-- `pingInterval: IntervalDuration` - how often ping message gets sent to server (to keep connection alive)
+- `pingInterval: Duration` - how often ping message gets sent to server (to keep connection alive)
 - `maxPingFailures: UInt` - max number of times ping-pong fail before disconnecting
 
 ```swift

--- a/Sources/EZNetworking/Services/WebSocket/Helpers/PingConfig.swift
+++ b/Sources/EZNetworking/Services/WebSocket/Helpers/PingConfig.swift
@@ -1,10 +1,10 @@
 import Foundation
 
 public struct PingConfig {
-    public let pingInterval: IntervalDuration
+    public let pingInterval: Duration
     public let maxPingFailures: UInt
 
-    public init(pingInterval: IntervalDuration = IntervalDuration.seconds(30), maxPingFailures: UInt = 3) {
+    public init(pingInterval: Duration = Duration.seconds(30), maxPingFailures: UInt = 3) {
         self.pingInterval = pingInterval
 
         if maxPingFailures == 0 {
@@ -15,42 +15,6 @@ public struct PingConfig {
     }
 
     func waitForPingInterval() async {
-        if #available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, visionOS 1.0, *) {
-            switch pingInterval {
-            case let .nanoseconds(nanoseconds):
-                try? await Task.sleep(for: .nanoseconds(nanoseconds))
-            case let .milliseconds(milliseconds):
-                try? await Task.sleep(for: .milliseconds(milliseconds))
-            case let .seconds(seconds):
-                try? await Task.sleep(for: .seconds(seconds))
-            }
-        } else {
-            // Fallback on earlier versions
-            switch pingInterval {
-            case let .nanoseconds(nanoseconds):
-                try? await Task.sleep(nanoseconds: nanoseconds)
-            case let .milliseconds(milliseconds):
-                try? await Task.sleep(nanoseconds: milliseconds * 1_000_000)
-            case let .seconds(seconds):
-                try? await Task.sleep(nanoseconds: seconds * 1_000_000_000)
-            }
-        }
-    }
-}
-
-public enum IntervalDuration: Equatable {
-    case nanoseconds(_ nanoseconds: UInt64)
-    case milliseconds(_ milliseconds: UInt64)
-    case seconds(_ seconds: UInt64)
-
-    public static func == (lhs: IntervalDuration, rhs: IntervalDuration) -> Bool {
-        switch (lhs, rhs) {
-        case let (.nanoseconds(lT), .nanoseconds(rT)),
-             let (.milliseconds(lT), .milliseconds(rT)),
-             let (.seconds(lT), .seconds(rT)):
-            lT == rT
-        default:
-            false
-        }
+        try? await Task.sleep(for: pingInterval)
     }
 }

--- a/Tests/EZNetworkingTests/Services/WebSocket/Helpers/PingConfigTests.swift
+++ b/Tests/EZNetworkingTests/Services/WebSocket/Helpers/PingConfigTests.swift
@@ -24,29 +24,3 @@ final class PingConfigTests {
         #expect(true, "waitForPingInterval did return")
     }
 }
-
-@Suite("Test IntervalDuration")
-final class IntervalDurationTests {
-    @Test("test IntervalDuration equality")
-    func intervalDurationEquality() {
-        let oneSecond = IntervalDuration.seconds(1)
-        let tenSecond = IntervalDuration.seconds(10)
-        let oneMilliseconds = IntervalDuration.milliseconds(1)
-        let tenMilliseconds = IntervalDuration.milliseconds(10)
-        let oneNanoseconds = IntervalDuration.nanoseconds(1)
-        let tenNanoseconds = IntervalDuration.nanoseconds(10)
-
-        #expect(oneSecond == oneSecond)
-        #expect(oneSecond != tenSecond)
-
-        #expect(oneMilliseconds == oneMilliseconds)
-        #expect(oneMilliseconds != tenMilliseconds)
-
-        #expect(oneNanoseconds == oneNanoseconds)
-        #expect(oneNanoseconds != tenNanoseconds)
-
-        #expect(oneSecond != oneMilliseconds)
-        #expect(oneMilliseconds != oneNanoseconds)
-        #expect(oneNanoseconds != oneSecond)
-    }
-}


### PR DESCRIPTION
## What's new?

Clean up IntervalDuration, replace with Foundation.Duration.

### Why is this change made?

IntervalDuration is meant to be an adapter of Duration while also supporting backward compatibility for versions before Duration was released. However, the minimum version for the Swift package has increased, and Duration will always be used, so IntervalDuration no longer provides any value over Duration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Streamlined WebSocket ping configuration mechanism with modern, standardized duration handling
  * Reduced code complexity in ping interval management while maintaining existing behavior

* **Documentation**
  * Updated ping configuration documentation to reflect current implementation

* **Tests**
  * Refined ping interval test suite for improved validation accuracy and consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Aldo10012/EZNetworking/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->