### PR TITLE
add RetryPolicy to RequestPerformer

### DIFF
--- a/Sources/EZNetworking/Services/Performers/RequestPerformer.swift
+++ b/Sources/EZNetworking/Services/Performers/RequestPerformer.swift
@@ -3,15 +3,18 @@ import Foundation
 public struct RequestPerformer: RequestPerformable {
     private let session: NetworkSession
     private let validator: ResponseValidator
+    private let retryPolicy: RetryPolicy
     private let decoder: JSONDecoder
 
     public init(
         session: NetworkSession = Session(),
         validator: ResponseValidator = DefaultResponseValidator(),
+        retryPolicy: RetryPolicy = .none,
         decoder: JSONDecoder = JSONDecoder()
     ) {
         self.session = session
         self.validator = validator
+        self.retryPolicy = retryPolicy
         self.decoder = decoder
     }
 
@@ -20,6 +23,19 @@ public struct RequestPerformer: RequestPerformable {
         decodeTo decodableObject: T.Type
     ) async throws -> T {
         try Task.checkCancellation()
+        if retryPolicy.enabled {
+            return try await performWithRetry(request: request, decodeTo: decodableObject)
+        } else {
+            return try await performSingle(request: request, decodeTo: decodableObject)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func performSingle<T: Decodable & Sendable>(
+        request: Request,
+        decodeTo decodableObject: T.Type
+    ) async throws -> T {
         do {
             let urlRequest = try request.getURLRequest()
             let (data, urlResponse) = try await session.urlSession.data(for: urlRequest)
@@ -33,7 +49,25 @@ public struct RequestPerformer: RequestPerformable {
         }
     }
 
-    // MARK: - Helpers
+    private func performWithRetry<T: Decodable & Sendable>(
+        request: Request,
+        decodeTo decodableObject: T.Type
+    ) async throws -> T {
+        var attemptCount: UInt = 0
+        while true {
+            do {
+                return try await performSingle(request: request, decodeTo: decodableObject)
+            } catch let cancellationError as CancellationError {
+                throw cancellationError
+            } catch {
+                attemptCount += 1
+                if retryPolicy.hasReachedMaxAttempts(attemptCount) {
+                    throw error
+                }
+                try await retryPolicy.sleep(forAttempt: attemptCount)
+            }
+        }
+    }
 
     private func decode<T: Decodable & Sendable>(_ data: Data, decodeTo decodableObject: T.Type) throws -> T {
         do {

--- a/Tests/EZNetworkingTests/Services/Performers/Mocks/MockRequestPerformerURLSession.swift
+++ b/Tests/EZNetworkingTests/Services/Performers/Mocks/MockRequestPerformerURLSession.swift
@@ -7,6 +7,7 @@ class MockRequestPerformerURLSession: URLSessionProtocol {
     var error: Error?
     var completion: ((Data?, URLResponse?, Error?) -> Void)?
     var sessionDelegate: SessionDelegate?
+    var numberOfRequestsMade = 0
 
     init(data: Data? = nil, urlResponse: URLResponse? = nil, error: Error? = nil) {
         self.data = data
@@ -15,6 +16,7 @@ class MockRequestPerformerURLSession: URLSessionProtocol {
     }
 
     func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        numberOfRequestsMade += 1
         if let error {
             throw error
         }

--- a/Tests/EZNetworkingTests/Services/Performers/RequestPerformerWithRetryPolicyTests.swift
+++ b/Tests/EZNetworkingTests/Services/Performers/RequestPerformerWithRetryPolicyTests.swift
@@ -1,0 +1,111 @@
+@testable import EZNetworking
+import Foundation
+import Testing
+
+@Suite("Test RequestPerformer with RetryPolicy")
+struct RequestPerformerWithRetryPolicyTests {
+    @Test("test perform(request:_) attempts only once if retryPolicy is .none")
+    func performsOnlyOnceIfRetryPolicyIsNone() async throws {
+        let mockSession = createMockURLSession(error: URLError(.notConnectedToInternet))
+        let sut = createRequestPerformer(urlSession: mockSession, retryPolicy: .none)
+
+        _ = try? await sut.perform(request: MockRequest(), decodeTo: EmptyResponse.self)
+        #expect(mockSession.numberOfRequestsMade == 1)
+    }
+
+    @Test("test perform(request:_) attempts only once if retryPolicy.enabled is false")
+    func performsOnlyOnceIfRetryPolicyEnabledIsFalse() async throws {
+        let retryPolicy = RetryPolicy(enabled: false)
+        let mockSession = createMockURLSession(error: URLError(.notConnectedToInternet))
+        let sut = createRequestPerformer(urlSession: mockSession, retryPolicy: retryPolicy)
+
+        _ = try? await sut.perform(request: MockRequest(), decodeTo: EmptyResponse.self)
+        #expect(mockSession.numberOfRequestsMade == 1)
+    }
+
+    @Test("test perform(request:_) retries up to maxAttempts times on persistent failure")
+    func retriesUpToMaxAttemptsOnPersistentFailure() async throws {
+        let retryPolicy = RetryPolicy(enabled: true, maxAttempts: 3, initialDelay: 0.01, maxDelay: 0.01)
+        let mockSession = createMockURLSession(error: URLError(.notConnectedToInternet))
+        let sut = createRequestPerformer(urlSession: mockSession, retryPolicy: retryPolicy)
+
+        _ = try? await sut.perform(request: MockRequest(), decodeTo: EmptyResponse.self)
+        #expect(mockSession.numberOfRequestsMade == 3)
+    }
+
+    @Test("test perform(request:_) throws the last error once maxAttempts is reached")
+    func throwsLastErrorOnceMaxAttemptsReached() async throws {
+        let retryPolicy = RetryPolicy(enabled: true, maxAttempts: 2, initialDelay: 0.01, maxDelay: 0.01)
+        let mockSession = createMockURLSession(error: URLError(.notConnectedToInternet))
+        let sut = createRequestPerformer(urlSession: mockSession, retryPolicy: retryPolicy)
+
+        await #expect(throws: NetworkingError.requestFailed(reason: .urlError(underlying: URLError(.notConnectedToInternet)))) {
+            try await sut.perform(request: MockRequest(), decodeTo: EmptyResponse.self)
+        }
+    }
+
+    @Test("test perform(request:_) with no error attempts only once even with retryPolicy set")
+    func performsOnlyOnceIfNoErrorEvenWithRetryPolicySetUp() async throws {
+        let retryPolicy = RetryPolicy(enabled: true, maxAttempts: 3, initialDelay: 0.01, maxDelay: 0.01)
+        let mockSession = createMockURLSession()
+        let sut = createRequestPerformer(urlSession: mockSession, retryPolicy: retryPolicy)
+
+        _ = try await sut.perform(request: MockRequest(), decodeTo: EmptyResponse.self)
+        #expect(mockSession.numberOfRequestsMade == 1)
+    }
+
+    @Test("test perform(request:_) always makes the initial attempt even when maxAttempts is 0")
+    func performsInitialAttemptEvenWhenMaxAttemptsIsZero() async throws {
+        let retryPolicy = RetryPolicy(enabled: true, maxAttempts: 0, initialDelay: 0.01, maxDelay: 0.01)
+        let mockSession = createMockURLSession(error: URLError(.notConnectedToInternet))
+        let sut = createRequestPerformer(urlSession: mockSession, retryPolicy: retryPolicy)
+
+        _ = try? await sut.perform(request: MockRequest(), decodeTo: EmptyResponse.self)
+        #expect(mockSession.numberOfRequestsMade == 1)
+    }
+}
+
+// MARK: - helpers
+
+private func createRequestPerformer(
+    urlSession: URLSessionProtocol = createMockURLSession(),
+    validator: ResponseValidator = DefaultResponseValidator(),
+    retryPolicy: RetryPolicy = .none,
+    decoder: JSONDecoder = JSONDecoder()
+) -> RequestPerformer {
+    RequestPerformer(
+        session: MockSession(urlSession: urlSession),
+        validator: validator,
+        retryPolicy: retryPolicy,
+        decoder: decoder
+    )
+}
+
+private func createMockURLSession(
+    data: Data? = MockData.mockPersonJsonData,
+    statusCode: Int = 200,
+    error: Error? = nil
+) -> MockRequestPerformerURLSession {
+    MockRequestPerformerURLSession(
+        data: data,
+        urlResponse: buildResponse(statusCode: statusCode),
+        error: error
+    )
+}
+
+private func buildResponse(statusCode: Int) -> HTTPURLResponse {
+    HTTPURLResponse(
+        url: URL(string: "https://example.com")!,
+        statusCode: statusCode,
+        httpVersion: nil,
+        headerFields: nil
+    )!
+}
+
+private struct MockRequest: Request {
+    var httpMethod: HTTPMethod { .GET }
+    var baseUrl: String { "https://www.example.com" }
+    var parameters: [HTTPParameter]? { nil }
+    var headers: [HTTPHeader]? { nil }
+    var body: HTTPBody? { nil }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable retry behavior for network requests.
  * Requests can retry recoverable failures up to a specified maximum number of attempts.
  * Cancellation errors stop immediately, while successful requests are not repeated.
  * Retry behavior is disabled by default for backward compatibility.

* **Tests**
  * Added coverage for disabled retries, maximum attempts, persistent failures, immediate success, and zero-attempt configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->