### PR TITLE
Clock refactor

### DIFF
--- a/Sources/EZNetworking/Core/Common/RetryPolicy.swift
+++ b/Sources/EZNetworking/Core/Common/RetryPolicy.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Configuration for automatic reconnection behavior, including strategy and retry limits for SSE connections.
 public struct RetryPolicy: Sendable {
     /// Determines if the client should automatically attempt to reconnect after unexpected stream errors.
-    public let enabled: Bool
+    internal let enabled: Bool
     /// The maximum number of retry attempts; set to nil for unlimited attempts.
     public let maxAttempts: UInt?
     /// The starting delay in seconds for the first reconnection attempt.
@@ -12,20 +12,41 @@ public struct RetryPolicy: Sendable {
     public let maxDelay: TimeInterval
     /// The multiplier used to calculate exponential backoff for subsequent retries.
     public let backoffMultiplier: Double
+    /// The clock used to schedule reconnection delays; injectable for deterministic testing.
+    private let clock: any Clock<Duration>
 
     /// Initializes a new configuration with specific reconnection and backoff parameters.
     public init(
-        enabled: Bool = true,
         maxAttempts: UInt? = nil,
         initialDelay: TimeInterval = 1.0,
         maxDelay: TimeInterval = 60.0,
         backoffMultiplier: Double = 2.0
+    ) {
+        self.init(
+            enabled: true,
+            maxAttempts: maxAttempts,
+            initialDelay: initialDelay,
+            maxDelay: maxDelay,
+            backoffMultiplier: backoffMultiplier,
+            clock: ContinuousClock()
+        )
+    }
+
+    /// Initializes a new configuration with specific reconnection and backoff parameters.
+    internal init(
+        enabled: Bool = true,
+        maxAttempts: UInt? = nil,
+        initialDelay: TimeInterval = 1.0,
+        maxDelay: TimeInterval = 60.0,
+        backoffMultiplier: Double = 2.0,
+        clock: any Clock<Duration> = ContinuousClock()
     ) {
         self.enabled = enabled
         self.maxAttempts = maxAttempts
         self.initialDelay = initialDelay
         self.maxDelay = maxDelay
         self.backoffMultiplier = backoffMultiplier
+        self.clock = clock
     }
 }
 
@@ -36,10 +57,15 @@ extension RetryPolicy {
     /// between retry attempts without managing the delay arithmetic themselves.
     /// Throws `CancellationError` if the task is cancelled; callers can use `try?` for silent handling.
     ///
-    /// - Parameter attemptCount: The current attempt number (1-indexed) used to derive the delay.
+    /// The `clock` parameter defaults to `ContinuousClock` in production, but can be swapped
+    /// for a test double so unit tests don't need to wait on real wall-clock time.
+    ///
+    /// - Parameters:
+    ///   - attemptCount: The current attempt number (1-indexed) used to derive the delay.
+    ///   - clock: The clock used to perform the suspension. Defaults to `ContinuousClock()`.
     func sleep(forAttempt attemptCount: UInt) async throws {
         let delay = calculateDelay(for: attemptCount)
-        try await Task.sleep(for: .seconds(delay))
+        try await clock.sleep(for: .seconds(delay))
     }
 
     /// Calculates the reconnection delay for a given attempt number.

--- a/Sources/EZNetworking/Services/WebSocket/Helpers/PingConfig.swift
+++ b/Sources/EZNetworking/Services/WebSocket/Helpers/PingConfig.swift
@@ -1,10 +1,20 @@
 import Foundation
 
-public struct PingConfig {
+public struct PingConfig: Sendable {
     public let pingInterval: Duration
     public let maxPingFailures: UInt
+    /// The clock used to schedule the wait between pings; injectable for deterministic testing.
+    private let clock: any Clock<Duration>
 
     public init(pingInterval: Duration = Duration.seconds(30), maxPingFailures: UInt = 3) {
+        self.init(pingInterval: pingInterval, maxPingFailures: maxPingFailures, clock: ContinuousClock())
+    }
+
+    internal init(
+        pingInterval: Duration = Duration.seconds(30),
+        maxPingFailures: UInt = 3,
+        clock: any Clock<Duration> = ContinuousClock()
+    ) {
         self.pingInterval = pingInterval
 
         if maxPingFailures == 0 {
@@ -12,9 +22,10 @@ public struct PingConfig {
         } else {
             self.maxPingFailures = maxPingFailures
         }
+        self.clock = clock
     }
 
     func waitForPingInterval() async {
-        try? await Task.sleep(for: pingInterval)
+        try? await clock.sleep(for: pingInterval)
     }
 }

--- a/Tests/EZNetworkingTests/Core/Common/Mocks/MockClock.swift
+++ b/Tests/EZNetworkingTests/Core/Common/Mocks/MockClock.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// A `Clock` test double that records requested sleep durations and resumes instantly,
+/// so tests can assert on backoff timing without waiting on real wall-clock time.
+final class MockClock: Clock, @unchecked Sendable {
+    struct Instant: InstantProtocol {
+        var offset: Duration
+
+        static func < (lhs: Instant, rhs: Instant) -> Bool {
+            lhs.offset < rhs.offset
+        }
+
+        func advanced(by duration: Duration) -> Instant {
+            Instant(offset: offset + duration)
+        }
+
+        func duration(to other: Instant) -> Duration {
+            other.offset - offset
+        }
+    }
+
+    private(set) var sleptDurations: [Duration] = []
+
+    var now = Instant(offset: .zero)
+    var minimumResolution: Duration = .zero
+
+    func sleep(until deadline: Instant, tolerance: Duration? = nil) async throws {
+        try Task.checkCancellation()
+        sleptDurations.append(now.duration(to: deadline))
+    }
+}

--- a/Tests/EZNetworkingTests/Core/Common/Mocks/MockClock.swift
+++ b/Tests/EZNetworkingTests/Core/Common/Mocks/MockClock.swift
@@ -27,5 +27,10 @@ final class MockClock: Clock, @unchecked Sendable {
     func sleep(until deadline: Instant, tolerance: Duration? = nil) async throws {
         try Task.checkCancellation()
         sleptDurations.append(now.duration(to: deadline))
+        // `Task.checkCancellation()` and the array append above never suspend, so without an
+        // explicit yield this "sleep" never hands control back to the scheduler. Ping-style loops
+        // that call this in a tight cycle would then monopolize their actor's executor forever,
+        // starving cancellation and any other work on that actor.
+        await Task.yield()
     }
 }

--- a/Tests/EZNetworkingTests/Core/Common/RetryPolicyTests.swift
+++ b/Tests/EZNetworkingTests/Core/Common/RetryPolicyTests.swift
@@ -103,50 +103,40 @@ struct RetryPolicyTests {
 
     // MARK: - Sleep Tests
 
-    @Test("sleep completes immediately for attempt 0", .disabled())
+    @Test("sleep requests zero duration for attempt 0")
     func sleepForAttemptZeroReturnsImmediately() async throws {
-        let policy = RetryPolicy(initialDelay: 10.0)
-        let clock = ContinuousClock()
-        let elapsed = await clock.measure {
-            try? await policy.sleep(forAttempt: 0)
-        }
-        #expect(elapsed < .milliseconds(500))
+        let clock = MockClock()
+        let policy = RetryPolicy(initialDelay: 10.0, clock: clock)
+        try await policy.sleep(forAttempt: 0)
+        #expect(clock.sleptDurations == [.seconds(0)])
     }
 
-    @Test("sleep duration matches calculated backoff delay", .disabled())
+    @Test("sleep duration matches calculated backoff delay")
     func sleepDurationMatchesBackoff() async throws {
-        let policy = RetryPolicy(initialDelay: 0.3, maxDelay: 60.0, backoffMultiplier: 2.0)
-        let clock = ContinuousClock()
-        let elapsed = await clock.measure {
-            try? await policy.sleep(forAttempt: 1) // 0.3 * 2^0 = 0.3s
-        }
-        #expect(elapsed >= .milliseconds(250))
-        #expect(elapsed < .seconds(2))
+        let clock = MockClock()
+        let policy = RetryPolicy(initialDelay: 0.3, maxDelay: 60.0, backoffMultiplier: 2.0, clock: clock)
+        try await policy.sleep(forAttempt: 1) // 0.3 * 2^0 = 0.3s
+        #expect(clock.sleptDurations == [.seconds(0.3)])
     }
 
-    @Test("sleep respects maxDelay cap", .disabled())
+    @Test("sleep respects maxDelay cap")
     func sleepRespectsMaxDelayCap() async throws {
-        let policy = RetryPolicy(initialDelay: 0.3, maxDelay: 0.3, backoffMultiplier: 100.0)
-        let clock = ContinuousClock()
-        let elapsed = await clock.measure {
-            try? await policy.sleep(forAttempt: 5) // uncapped: enormous; capped at 0.3s
-        }
-        #expect(elapsed >= .milliseconds(250))
-        #expect(elapsed < .seconds(2))
+        let clock = MockClock()
+        let policy = RetryPolicy(initialDelay: 0.3, maxDelay: 0.3, backoffMultiplier: 100.0, clock: clock)
+        try await policy.sleep(forAttempt: 5) // uncapped: enormous; capped at 0.3s
+        #expect(clock.sleptDurations == [.seconds(0.3)])
     }
 
-    @Test("sleep completes without throwing when task is cancelled", .disabled())
+    @Test("sleep completes without throwing when task is cancelled")
     func sleepHandlesCancellationGracefully() async {
-        let policy = RetryPolicy(initialDelay: 60.0)
-        let clock = ContinuousClock()
+        let clock = MockClock()
+        let policy = RetryPolicy(initialDelay: 60.0, clock: clock)
         let task = Task {
-            await clock.measure {
-                try? await policy.sleep(forAttempt: 1) // would sleep 60s without cancellation
-            }
+            try? await policy.sleep(forAttempt: 1) // would sleep 60s without cancellation
         }
         task.cancel()
-        let elapsed = await task.value
-        #expect(elapsed < .seconds(1))
+        await task.value
+        #expect(clock.sleptDurations.isEmpty)
     }
 
     // MARK: - RetryPolicy.none

--- a/Tests/EZNetworkingTests/Services/ServerSentEvent/ServerSentEventManagerWithRetryTests.swift
+++ b/Tests/EZNetworkingTests/Services/ServerSentEvent/ServerSentEventManagerWithRetryTests.swift
@@ -18,39 +18,47 @@ struct ServerSentEventManagerWithRetryPolicyTests {
 
     @Test("test .connect() attempts connect only once if retryPolicy.enabled is false")
     func connectsOnlyOnceIfretryPolicyEnabledIsFalse() async throws {
-        let retryPolicy = RetryPolicy(enabled: false)
+        let clock = MockClock()
+        let retryPolicy = RetryPolicy(enabled: false, clock: clock)
         let underlyingError = URLError(.notConnectedToInternet)
         let mockSession = createMockURLSession(error: underlyingError)
         let manager = createSSEManager(request: sseRequest, urlSession: mockSession, retryPolicy: retryPolicy)
 
         try? await manager.connect()
         #expect(mockSession.numberOfRequestsMade == 1)
+        #expect(clock.sleptDurations.isEmpty)
     }
 
     @Test("test .connect() attempts connect 3 times if retryPolicy.maxAttempts is 3")
     func connectsThreeTimesIfretryPolicyMaxAttemptsIs3() async throws {
-        let retryPolicy = RetryPolicy(enabled: true, maxAttempts: 3)
+        let clock = MockClock()
+        let retryPolicy = RetryPolicy(enabled: true, maxAttempts: 3, clock: clock)
         let underlyingError = URLError(.notConnectedToInternet)
         let mockSession = createMockURLSession(error: underlyingError)
         let manager = createSSEManager(request: sseRequest, urlSession: mockSession, retryPolicy: retryPolicy)
 
         try? await manager.connect()
         #expect(mockSession.numberOfRequestsMade == 3)
+        // Exponential backoff before attempts 2 and 3: 1.0 * 2^0 = 1.0s, then 1.0 * 2^1 = 2.0s
+        #expect(clock.sleptDurations == [.seconds(1.0), .seconds(2.0)])
     }
 
     @Test("test .connect() with no error attempts connect 1 time even with retryPolicy set")
     func connectsOnlyOnceIfNoErrorEvenWithretryPolicySetUp() async throws {
-        let retryPolicy = RetryPolicy(enabled: true, maxAttempts: 3)
+        let clock = MockClock()
+        let retryPolicy = RetryPolicy(enabled: true, maxAttempts: 3, clock: clock)
         let mockSession = createMockURLSession()
         let manager = createSSEManager(request: sseRequest, urlSession: mockSession, retryPolicy: retryPolicy)
 
         try? await manager.connect()
         #expect(mockSession.numberOfRequestsMade == 1)
+        #expect(clock.sleptDurations.isEmpty)
     }
 
     @Test("test manual disconnect prevents automatic reconnection")
     func manualDisconnectPreventsAutomaticReconnection() async throws {
-        let retryPolicy = RetryPolicy(enabled: true, maxAttempts: 5)
+        let clock = MockClock()
+        let retryPolicy = RetryPolicy(enabled: true, maxAttempts: 5, clock: clock)
         let mockSession = createMockURLSession()
         let manager = createSSEManager(
             request: sseRequest,
@@ -64,11 +72,13 @@ struct ServerSentEventManagerWithRetryPolicyTests {
         try? await Task.sleep(for: .seconds(0.5))
 
         #expect(mockSession.numberOfRequestsMade == 1)
+        #expect(clock.sleptDurations.isEmpty)
     }
 
     @Test("test terminate prevents automatic reconnection")
     func terminatePreventsAutomaticReconnection() async throws {
-        let retryPolicy = RetryPolicy(enabled: true, maxAttempts: 5)
+        let clock = MockClock()
+        let retryPolicy = RetryPolicy(enabled: true, maxAttempts: 5, clock: clock)
         let mockSession = createMockURLSession()
         let manager = createSSEManager(
             request: sseRequest,
@@ -82,13 +92,16 @@ struct ServerSentEventManagerWithRetryPolicyTests {
         try? await Task.sleep(for: .seconds(0.5))
 
         #expect(mockSession.numberOfRequestsMade == 1)
+        #expect(clock.sleptDurations.isEmpty)
     }
 
     @Test("test maxAttempts zero means no retries")
     func maxAttemptsZeroMeansNoRetries() async throws {
+        let clock = MockClock()
         let retryPolicy = RetryPolicy(
             enabled: true,
-            maxAttempts: 0
+            maxAttempts: 0,
+            clock: clock
         )
         let underlyingError = URLError(.notConnectedToInternet)
         let mockSession = createMockURLSession(error: underlyingError)
@@ -99,11 +112,13 @@ struct ServerSentEventManagerWithRetryPolicyTests {
         )
         try? await manager.connect()
         #expect(mockSession.numberOfRequestsMade == 0)
+        #expect(clock.sleptDurations.isEmpty)
     }
 
     @Test("test reconnect attempt when stream ends without error")
     func reconnectAttemptWhenStreamEndsWithoutError() async throws {
-        let retryPolicy = RetryPolicy(enabled: true, maxAttempts: 1)
+        let clock = MockClock()
+        let retryPolicy = RetryPolicy(enabled: true, maxAttempts: 1, clock: clock)
         let mockSession = createMockURLSession()
         let manager = createSSEManager(
             request: sseRequest,
@@ -140,11 +155,14 @@ struct ServerSentEventManagerWithRetryPolicyTests {
             SSEConnectionState.connected
         ])
         #expect(mockSession.capturedRequests.last?.value(forHTTPHeaderField: "Last-Event-ID") == "event-123")
+        // The reconnect succeeds on its first attempt, so retryPolicy's backoff delay never gets used.
+        #expect(clock.sleptDurations.isEmpty)
     }
 
     @Test("test ServerSentEventManager reconnects when stream ends with error")
     func reconnectAttemptWhenStreamEndsWithError() async throws {
-        let retryPolicy = RetryPolicy(enabled: true, maxAttempts: 1)
+        let clock = MockClock()
+        let retryPolicy = RetryPolicy(enabled: true, maxAttempts: 1, clock: clock)
         let mockSession = createMockURLSession()
         let manager = createSSEManager(
             request: sseRequest,
@@ -179,6 +197,8 @@ struct ServerSentEventManagerWithRetryPolicyTests {
             SSEConnectionState.connected
         ])
         #expect(mockSession.capturedRequests.last?.value(forHTTPHeaderField: "Last-Event-ID") == "event-123")
+        // The reconnect succeeds on its first attempt, so retryPolicy's backoff delay never gets used.
+        #expect(clock.sleptDurations.isEmpty)
     }
 }
 

--- a/Tests/EZNetworkingTests/Services/WebSocket/Helpers/PingConfigTests.swift
+++ b/Tests/EZNetworkingTests/Services/WebSocket/Helpers/PingConfigTests.swift
@@ -17,10 +17,11 @@ final class PingConfigTests {
         #expect(sut.maxPingFailures == 1)
     }
 
-    @Test("test .waitForPingInterval()")
+    @Test("test .waitForPingInterval() sleeps for the configured pingInterval")
     func testWaitForPingInterval() async {
-        let sut = PingConfig(pingInterval: .nanoseconds(1))
+        let clock = MockClock()
+        let sut = PingConfig(pingInterval: .seconds(3), clock: clock)
         await sut.waitForPingInterval()
-        #expect(true, "waitForPingInterval did return")
+        #expect(clock.sleptDurations == [.seconds(3)])
     }
 }

--- a/Tests/EZNetworkingTests/Services/WebSocket/WebSocketTestCase.swift
+++ b/Tests/EZNetworkingTests/Services/WebSocket/WebSocketTestCase.swift
@@ -5,11 +5,16 @@ import Testing
 /// Shared setup/teardown and helpers for the `WebSocket.*` test suites.
 ///
 /// Each suite subclasses this instead of redefining its own mocks, `getSut()`,
-/// and `performConnect(...)` helper. Suites that need a non-default `PingConfig`
-/// or `MockURLSessionWebSocketTask` (e.g. `WebSocketConnectTests`) override `init()`
-/// and call `super.init(pingConfig:wsTask:)`; the rest inherit the default `init()`.
+/// and `performConnect(...)` helper. Suites that need a non-default `pingInterval`/
+/// `maxPingFailures` or `MockURLSessionWebSocketTask` (e.g. `WebSocketConnectTests`)
+/// override `init()` and call `super.init(pingInterval:maxPingFailures:wsTask:)`;
+/// the rest inherit the default `init()`.
+///
+/// `pingConfig` is always built with `pingClock`, a `MockClock`, so the ping loop's
+/// delays resolve instantly and tests can assert on the recorded `pingClock.sleptDurations`.
 class WebSocketTestCase {
     var pingConfig: PingConfig!
+    let pingClock = MockClock()
     var wsTask: MockURLSessionWebSocketTask!
     var urlSession: MockWebSockerURLSession!
     var wsInterceptor: MockWebSocketTaskInterceptor!
@@ -19,15 +24,16 @@ class WebSocketTestCase {
     // MARK: - setup
 
     init(
-        pingConfig: PingConfig = PingConfig(pingInterval: .seconds(1), maxPingFailures: 1),
+        pingInterval: Duration = .seconds(1),
+        maxPingFailures: UInt = 1,
         wsTask: MockURLSessionWebSocketTask = MockURLSessionWebSocketTask()
     ) {
-        setup(pingConfig: pingConfig)
+        setup(pingInterval: pingInterval, maxPingFailures: maxPingFailures)
         setupSession(withTask: wsTask)
     }
 
-    func setup(pingConfig: PingConfig) {
-        self.pingConfig = pingConfig
+    func setup(pingInterval: Duration, maxPingFailures: UInt) {
+        pingConfig = PingConfig(pingInterval: pingInterval, maxPingFailures: maxPingFailures, clock: pingClock)
     }
 
     func setupSession(withTask wsTask: MockURLSessionWebSocketTask) {

--- a/Tests/EZNetworkingTests/Services/WebSocket/WebSocket_Connect_Tests.swift
+++ b/Tests/EZNetworkingTests/Services/WebSocket/WebSocket_Connect_Tests.swift
@@ -7,7 +7,7 @@ import Testing
 @Suite("Test WebSocket.connect()")
 final class WebSocketConnectTests: WebSocketTestCase {
     init() {
-        super.init(pingConfig: PingConfig(pingInterval: .nanoseconds(1), maxPingFailures: 0))
+        super.init(pingInterval: .seconds(30), maxPingFailures: 0)
     }
 
     // MARK: .connect()
@@ -82,7 +82,7 @@ final class WebSocketConnectTests: WebSocketTestCase {
 
     @Test("test calling .connect fails if ping does not receive pong after 3 failed attempts")
     func callingConnectFailsIfPingDoesNotReceivePongAfter3FailedAttempts() async throws {
-        setup(pingConfig: PingConfig(pingInterval: .nanoseconds(1), maxPingFailures: 3))
+        setup(pingInterval: .seconds(30), maxPingFailures: 3)
         setupSession(withTask: MockURLSessionWebSocketTask(pingThrowsError: true))
         let sut = getSut()
 
@@ -90,11 +90,12 @@ final class WebSocketConnectTests: WebSocketTestCase {
         try await Task.sleep(nanoseconds: 1_000_000_000)
 
         #expect(wsTask.pingFailureCount == 3)
+        #expect(pingClock.sleptDurations == [.seconds(30), .seconds(30), .seconds(30)])
     }
 
     @Test("test captured error from calling .connect if ping does not receive pong")
     func capturedErrorFromCallingConnectIfPingDoesNotReceivePong() async throws {
-        setup(pingConfig: PingConfig(pingInterval: .nanoseconds(1), maxPingFailures: 1))
+        setup(pingInterval: .seconds(30), maxPingFailures: 1)
         setupSession(withTask: MockURLSessionWebSocketTask(pingThrowsError: true))
         let sut = getSut()
 
@@ -102,5 +103,6 @@ final class WebSocketConnectTests: WebSocketTestCase {
         try await Task.sleep(nanoseconds: 1_000_000_000)
 
         #expect(wsTask.pingError as? MockURLSessionWebSocketTaskError == MockURLSessionWebSocketTaskError.pingError)
+        #expect(pingClock.sleptDurations == [.seconds(30)])
     }
 }

--- a/Tests/EZNetworkingTests/Services/WebSocket/WebSocket_StateEvents_Tests.swift
+++ b/Tests/EZNetworkingTests/Services/WebSocket/WebSocket_StateEvents_Tests.swift
@@ -114,7 +114,7 @@ final class WebSocketStateEventsTests: WebSocketTestCase {
 
     @Test("test stateEvents when connecting and ping-pong fails")
     func stateEventsWhenConnectingThenPingPongError() async throws {
-        setup(pingConfig: PingConfig(pingInterval: .nanoseconds(1), maxPingFailures: 3))
+        setup(pingInterval: .seconds(30), maxPingFailures: 3)
         setupSession(withTask: MockURLSessionWebSocketTask(pingThrowsError: true))
         let sut = getSut()
 
@@ -139,6 +139,7 @@ final class WebSocketStateEventsTests: WebSocketTestCase {
 
         _ = await stateTask.value
         #expect(receivedState == expectedStates)
+        #expect(pingClock.sleptDurations == [.seconds(30), .seconds(30), .seconds(30)])
     }
 
     @Test("test stateEvents when connecting and receive message fails")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Retry and WebSocket timing now use consistent clock-based scheduling for more predictable backoff and ping intervals.
  * Retry delays continue to support exponential backoff, maximum-delay limits, cancellation, and zero-delay operation.
  * WebSocket reconnection and ping-failure behavior has been strengthened and verified across common connection scenarios.

* **API Changes**
  * `RetryPolicy` is now enabled by default and no longer exposes public configuration for disabling retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->